### PR TITLE
Multi drop move and Simulation

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## Pending
+
+- Add support for `move_drops` RPC, which moves up to five drops at once using
+  group capacitance as feedback and adds support for control of more move options,
+  including the gain to use, the timeout, and how much trailing data to collect
+  ("post_capture_time").
+- Changes move_drop to report calibrated capacitance in its return data
+- Change background threads to greenlets
+- Add simulation mode to pdserver with --sim argument
+
 ## v0.5.0 (Jun 30, 2021)
 
 - Add support for low-gain active capacitance measurement

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## Pending
+## v0.6.0 (Feb 16, 2022)
 
 - Add support for `move_drops` RPC, which moves up to five drops at once using
   group capacitance as feedback and adds support for control of more move options,

--- a/purpledrop/controller.py
+++ b/purpledrop/controller.py
@@ -1,0 +1,939 @@
+"""Defines PurpleDropController, a wrapper around a device which provides the
+primary control interface, and a bridge between the device messaging and HTTP
+interfaces
+"""
+
+import fnmatch
+import gevent
+import logging
+import struct
+import threading
+import time
+from typing import Any, AnyStr, Callable, Dict, List, Optional, Sequence
+
+from purpledrop.calibration import ElectrodeOffsetCalibration
+from purpledrop.electrode_board import Board
+from purpledrop.exceptions import NoDeviceException
+import purpledrop.messages as messages
+import purpledrop.protobuf.messages_pb2 as messages_pb2
+from .move_drop import move_drop, move_drops, MoveDropResult
+
+logger = logging.getLogger("controller")
+
+# Versions of purpledrop software supported by this driver
+SUPPORTED_VERSIONS = [
+    "v0.5.*",
+]
+
+def validate_version(v):
+    for pattern in SUPPORTED_VERSIONS:
+        if fnmatch.fnmatch(v, pattern):
+            return True
+    return False
+
+N_PINS = 128
+N_MASK_BYTES = N_PINS/8
+
+# Compute coefficients to convert integrated voltage to integrated charge
+# These values are nominal calculated values, not calibrated in any way
+# Divide by the voltage to get farads.
+# First stage gain
+GAIN1 = 2.0
+# Integrator gain (Vout per integrated input V*s)
+GAIN2 = 25000.0
+# Output stage gain
+GAIN3 = 22.36
+# Sense resistances for high/low gain
+RLOW = 33.0
+RHIGH = 220.0
+CAPGAIN_HIGH = RHIGH * GAIN1 * GAIN2 * GAIN3 * 4096. / 3.3
+CAPGAIN_LOW = RLOW * GAIN1 * GAIN2 * GAIN3 * 4096. / 3.3
+
+def pinlist2bool(pins):
+    pin_state = [False] * N_PINS
+
+    for p in pins:
+        if(p >= N_PINS):
+            raise ValueError(f"Pin {p} is invalid. Must be < {N_PINS}")
+        pin_state[p] = True
+    return pin_state
+
+def pinlist2mask(pins):
+    mask = [0] * int(((N_PINS + 7) / 8))
+    for p in pins:
+        word = int(p / 8)
+        bit = p % 8
+        mask[word] |= (1<<bit)
+    return mask
+
+def get_pb_timestamp():
+    """Get a protobuf timestamp for the current system time
+    """
+    time_f = time.time()
+    ts = messages_pb2.Timestamp()
+    ts.seconds = int(time_f)
+    ts.nanos = int((time_f % 1) * 1e9)
+    return ts
+
+class PinState(object):
+    """Data record to store the state of purpledrop pin setting, including
+    active pins and capacitance scan groups
+    """
+    N_DRIVE_GROUPS = 2
+    N_SCAN_GROUPS = 5
+
+    class PinGroup(object):
+        def __init__(self, pin_mask: Sequence[int], setting: int):
+            self.pin_mask = pin_mask
+            self.setting = setting
+
+    class DriveGroup(PinGroup):
+        def __init__(self, pin_mask=None, duty_cycle=255):
+            if pin_mask is None:
+                pin_mask = pinlist2bool([])
+            super().__init__(pin_mask, duty_cycle)
+
+        @property
+        def duty_cycle(self):
+            return self.setting
+
+        @duty_cycle.setter
+        def duty_cycle(self, dc):
+            self.setting = dc
+
+        def to_dict(self):
+            return {
+                'pins': self.pin_mask,
+                'duty_cycle': self.duty_cycle,
+            }
+
+    class ScanGroup(PinGroup):
+        def __init__(self, pin_mask=None, setting=0):
+            if pin_mask is None:
+                pin_mask = pinlist2bool([])
+            super().__init__(pin_mask, setting)
+
+        def to_dict(self):
+            return {
+                'pins': self.pin_mask,
+                'setting': self.setting,
+            }
+
+    def __init__(self):
+        self.drive_groups = [self.DriveGroup() for _ in range(self.N_DRIVE_GROUPS)]
+        self.scan_groups = [self.ScanGroup() for _ in range(self.N_SCAN_GROUPS)]
+
+    def to_dict(self):
+        return {
+            'drive_groups': [x.to_dict() for x in self.drive_groups],
+            'scan_groups': [x.to_dict() for x in self.scan_groups],
+        }
+
+class PurpleDropController(object):
+    # Define the method names which will be made available via RPC server
+    RPC_METHODS = [
+        'get_board_definition',
+        'get_parameter_definitions',
+        'get_parameter',
+        'set_parameter',
+        'get_bulk_capacitance',
+        'get_scan_capacitance',
+        'get_group_capacitance',
+        'get_active_capacitance',
+        'set_capacitance_group',
+        'set_electrode_pins',
+        'get_electrode_pins',
+        'set_feedback_command',
+        'move_drop',
+        'move_drops',
+        'get_temperatures',
+        'set_pwm_duty_cycle',
+        'get_hv_supply_voltage',
+        'calibrate_capacitance_offset',
+        'get_device_info',
+        'read_gpio',
+        'write_gpio',
+        'set_scan_gains',
+        'get_scan_gains',
+        'set_electrode_calibration',
+    ]
+
+    def __init__(self, purpledrop, board_definition: Board, electrode_calibration: Optional[ElectrodeOffsetCalibration]=None):
+        self.purpledrop = purpledrop
+        self.board_definition = board_definition
+
+        self.active_capacitance = 0.0
+        self.electrode_calibration = electrode_calibration
+        self.raw_scan_capacitance: List[float] = []
+        self.calibrated_scan_capacitance: List[float] = []
+        self.raw_group_capacitance: List[float] = []
+        self.calibrated_group_capacitance: List[float] = []
+        self.scan_gains = [CAPGAIN_HIGH] * N_PINS
+        self.temperatures: Sequence[float] = []
+        self.duty_cycles: Dict[int, float] = {}
+        self.hv_supply_voltage = 0.0
+        self.parameter_list: List[dict] = []
+        self.lock = gevent.lock.RLock()
+        self.event_listeners: List[Callable] = []
+        self.active_capacitance_counter = 0
+        self.group_capacitance_counter = 0
+        self.duty_cycle_updated_counter = 0
+        self.hv_regulator_counter = 0
+        self.pin_state = PinState()
+
+        def msg_filter(msg):
+            desired_types = [
+                messages.ActiveCapacitanceMsg,
+                messages.BulkCapacitanceMsg,
+                messages.CommandAckMsg,
+                messages.DutyCycleUpdatedMsg,
+                messages.TemperatureMsg,
+                messages.HvRegulatorMsg,
+            ]
+
+            for t in desired_types:
+                if isinstance(msg, t):
+                    return True
+            return False
+
+        if self.purpledrop.connected():
+            self.__on_connected()
+        self.purpledrop.register_connected_callback(self.__on_connected)
+        self.purpledrop.register_disconnected_callback(self.__on_disconnected)
+
+        self.listener = self.purpledrop.get_async_listener(self.__message_callback, msg_filter)
+
+    def __on_connected(self):
+        self.__set_scan_gains()
+        self.__get_parameter_descriptors()
+        software_version = self.get_software_version()
+        if not validate_version(software_version):
+            logger.error(f"Unsupported software version '{software_version}'. This driver may not" + \
+                "work correcly, and you should upgrade your purpledrop firmware to one of the following: " +  \
+                    f"{SUPPORTED_VERSIONS}")
+        self.__send_device_info_event(
+            True,
+            self.purpledrop.connected_serial_number() or '',
+            software_version or ''
+        )
+        if self.electrode_calibration is not None:
+            logger.info("Loading electrode calibration")
+            self.set_electrode_calibration(self.electrode_calibration.voltage, self.electrode_calibration.offsets)
+
+    def __on_disconnected(self):
+        self.__send_device_info_event(False, '', '')
+
+    def __ensure_device_connected(self):
+        """Raises NoDeviceException unless there is a purpledrop connected
+        """
+        if not self.purpledrop.connected():
+            raise NoDeviceException("No purpledrop device connected")
+        return True
+
+    def __send_device_info_event(self, connected: bool, serial_number: str, software_version: str):
+        event = messages_pb2.PurpleDropEvent()
+        event.device_info.connected = connected
+        event.device_info.serial_number = serial_number
+        event.device_info.software_version = software_version
+        self.__fire_event(event)
+
+    def __get_parameter_descriptors(self):
+        """Request and receive the list of parameters from device
+        """
+        with self.purpledrop.get_sync_listener(messages.ParameterDescriptorMsg) as listener:
+            self.purpledrop.send_message(messages.ParameterDescriptorMsg())
+            descriptors = []
+            while True:
+                msg = listener.next(timeout=1.0)
+                if msg is None:
+                    logger.error("Timed out waiting for parameter descriptors")
+                    break
+                descriptors.append({
+                    'id': msg.param_id,
+                    'name': msg.name,
+                    'description': msg.description,
+                    'type': msg.type,
+                })
+                if msg.sequence_number == msg.sequence_total - 1:
+                    break
+            self.parameter_list = descriptors
+
+    def __set_scan_gains(self, gains: Sequence[bool]=None):
+        """Setup gains used for capacitance scan
+
+        If no gains are provided, the gains will be set based on the "oversized"
+        electrodes defined in the active board definition. Any oversized
+        electrodes are set to low gain, and the rest to high gain.
+
+        Args:
+          gains: A list of booleans. True indicates low gain should be used for
+          the corresponding electrode
+        """
+        if gains is None:
+            gains = [False] * N_PINS
+            for pin in self.board_definition.oversized_electrodes:
+                gains[pin] = True # low gain
+        self.scan_gains = list(map(lambda x: CAPGAIN_LOW if x else CAPGAIN_HIGH, gains))
+
+        msg = messages.SetGainMsg()
+        msg.gains = list(map(lambda x: 1 if x else 0, gains))
+        with self.purpledrop.get_sync_listener(messages.CommandAckMsg) as listener:
+            self.purpledrop.send_message(msg)
+            ack = listener.next(timeout=1.0)
+            if ack is None:
+                logger.error("Got no ACK for SetGains message")
+
+    def __calibrate_capacitance(self, raw, gain):
+        # Can't measure capacitance unless high voltage is on
+        if self.hv_supply_voltage < 60.0:
+            return 0.0
+        # Return as pF
+        return raw * 1e12 / gain / self.hv_supply_voltage
+
+    def __calibrate_group_capacitance(self, raw):
+        calibrated_group_capacitance = [0.0] * len(raw)
+        for i in range(len(raw)):
+            if self.pin_state.scan_groups[i].setting == 0:
+                gain = CAPGAIN_HIGH
+            else:
+                gain = CAPGAIN_LOW
+            calibrated_group_capacitance[i] = self.__calibrate_capacitance(raw[i], gain)
+        return calibrated_group_capacitance
+
+    def __message_callback(self, msg):
+        if isinstance(msg, messages.ActiveCapacitanceMsg):
+            # TODO: I-sense resistor values are adjustable, and the
+            # CAPGAIN_HIGH/CAPGAIN_LOW should be gotten from the device at some
+            # point, rather than duplicated here
+            capgain = CAPGAIN_LOW if (msg.settings & 1 == 1) else CAPGAIN_HIGH
+            self.active_capacitance = self.__calibrate_capacitance(msg.measurement - msg.baseline, capgain)
+            self.active_capacitance_counter += 1
+            # Throttle the events. 500Hz messages is a lot for the browser to process.
+            # This also means logs don't have a full resolution, and it would be better
+            # if clients could choose what they get
+            if (self.active_capacitance_counter % 10) == 0:
+                cap_event = messages_pb2.PurpleDropEvent()
+                cap_event.active_capacitance.baseline = msg.baseline
+                cap_event.active_capacitance.measurement = msg.measurement
+                cap_event.active_capacitance.calibrated = float(self.active_capacitance)
+                cap_event.active_capacitance.timestamp.CopyFrom(get_pb_timestamp())
+                self.__fire_event(cap_event)
+
+        elif isinstance(msg, messages.BulkCapacitanceMsg):
+            if(msg.group_scan != 0):
+                self.group_capacitance_counter += 1
+                self.raw_group_capacitance = msg.measurements
+                self.calibrated_group_capacitance = self.__calibrate_group_capacitance(msg.measurements)
+                if (self.group_capacitance_counter % 10) == 0:
+                    group_event = messages_pb2.PurpleDropEvent()
+                    group_event.group_capacitance.timestamp.CopyFrom(get_pb_timestamp())
+                    group_event.group_capacitance.measurements[:] = self.calibrated_group_capacitance
+                    group_event.group_capacitance.raw_measurements[:] = self.raw_group_capacitance
+                    self.__fire_event(group_event)
+            else:
+                # Scan capacitance measurements are broken up into multiple messages
+                if len(self.raw_scan_capacitance) < msg.start_index + msg.count:
+                    self.raw_scan_capacitance.extend([0] * (msg.start_index + msg.count - len(self.raw_scan_capacitance)))
+                    self.calibrated_scan_capacitance.extend([0] * (msg.start_index + msg.count - len(self.calibrated_scan_capacitance)))
+                for i in range(msg.count):
+                    chan = msg.start_index + i
+                    gain = self.scan_gains[chan]
+                    self.raw_scan_capacitance[chan] = msg.measurements[i]
+                    self.calibrated_scan_capacitance[chan] = self.__calibrate_capacitance(msg.measurements[i], gain)
+
+                # Fire event on the last group
+                if msg.start_index + msg.count == 128:
+                    bulk_event = messages_pb2.PurpleDropEvent()
+                    def make_cap_measurement(raw, calibrated):
+                        m = messages_pb2.CapacitanceMeasurement()
+                        m.raw = float(raw)
+                        m.capacitance = float(calibrated)
+                        return m
+                    bulk_event.scan_capacitance.measurements.extend(
+                        [make_cap_measurement(raw, cal)
+                        for (raw, cal) in zip(self.raw_scan_capacitance, self.calibrated_scan_capacitance)]
+                    )
+                    bulk_event.scan_capacitance.timestamp.CopyFrom(get_pb_timestamp())
+                    self.__fire_event(bulk_event)
+
+        elif isinstance(msg, messages.DutyCycleUpdatedMsg):
+            self.duty_cycle_updated_counter += 1
+            if (self.duty_cycle_updated_counter%10) == 0:
+                # Update local state of duty cycle
+                self.pin_state.drive_groups[0].duty_cycle = msg.duty_cycle_A
+                self.pin_state.drive_groups[1].duty_cycle = msg.duty_cycle_B
+
+                # Publish event with new values
+                duty_cycle_event = messages_pb2.PurpleDropEvent()
+                duty_cycle_event.duty_cycle_updated.timestamp.CopyFrom(get_pb_timestamp())
+                duty_cycle_event.duty_cycle_updated.duty_cycles[:] = [msg.duty_cycle_A, msg.duty_cycle_B]
+                self.__fire_event(duty_cycle_event)
+
+        elif isinstance(msg, messages.HvRegulatorMsg):
+            self.hv_supply_voltage = msg.voltage
+            self.hv_regulator_counter += 1
+            if (self.hv_regulator_counter % 10) == 0:
+                event = messages_pb2.PurpleDropEvent()
+                event.hv_regulator.voltage = msg.voltage
+                event.hv_regulator.v_target_out = msg.v_target_out
+                event.hv_regulator.timestamp.CopyFrom(get_pb_timestamp())
+                self.__fire_event(event)
+
+        elif isinstance(msg, messages.TemperatureMsg):
+            self.temperatures = [float(x) / 100.0 for x in msg.measurements]
+            event = messages_pb2.PurpleDropEvent()
+            event.temperature_control.temperatures[:] = self.temperatures
+            duty_cycles = []
+            for i in range(len(self.temperatures)):
+                duty_cycles.append(self.duty_cycles.get(i, 0.0))
+            event.temperature_control.duty_cycles[:] = duty_cycles
+            event.temperature_control.timestamp.CopyFrom(get_pb_timestamp())
+            self.__fire_event(event)
+
+    def __fire_event(self, event):
+        with self.lock:
+            for listener in self.event_listeners:
+                listener(event)
+
+    def __get_parameter_definition(self, id):
+        for p in self.parameter_list:
+            if p['id'] == id:
+                return p
+        return None
+
+    def __fire_pinstate_event(self):
+        event = messages_pb2.PurpleDropEvent()
+        for g in self.pin_state.drive_groups:
+            event.electrode_state.drive_groups.add(electrodes=g.pin_mask, setting=g.setting)
+        for g in self.pin_state.scan_groups:
+            event.electrode_state.scan_groups.add(electrodes=g.pin_mask, setting=g.setting)
+
+        self.__fire_event(event)
+
+    def get_software_version(self) -> Optional[str]:
+        with self.purpledrop.get_sync_listener(msg_filter=messages.DataBlobMsg) as listener:
+            versionRequest = messages.DataBlobMsg()
+            versionRequest.blob_id = messages.DataBlobMsg.SOFTWARE_VERSION_ID
+            self.purpledrop.send_message(versionRequest)
+            msg = listener.next(0.5)
+            if msg is None:
+                software_version = None
+                logger.warning("Timed out requesting software version")
+            else:
+                software_version = msg.payload.decode('utf-8')
+            return software_version
+
+    def register_event_listener(self, func):
+        """Register a callback for state update events
+        """
+        with self.lock:
+            self.event_listeners.append(func)
+
+    def unregister_event_listener(self, func):
+        """Remove a previously registered listener
+        """
+        with self.lock:
+            if func in self.event_listeners:
+                self.event_listeners.remove(func)
+
+    def active_capacitance_collector(self):
+        """Return a collector for active capacitance reports
+        """
+
+        def match(msg):
+            return isinstance(msg, messages.ActiveCapacitanceMsg)
+        def transform(msg):
+            gain = CAPGAIN_LOW if (msg.settings & 1 == 1) else CAPGAIN_HIGH
+            raw = msg.measurement - msg.baseline
+            calibrated = self.__calibrate_capacitance(raw, gain)
+            return raw, calibrated
+
+        return self.purpledrop.get_sync_listener(match, transform)
+
+    def wait_for_active_capacitance(self, timeout=1.0):
+        """Wait for the next active capacitance update to be recieved and return it
+        """
+        with self.purpledrop.get_sync_listener(messages.ActiveCapacitanceMsg) as listener:
+            msg = listener.next(timeout)
+
+        if msg is None:
+            raise TimeoutError("Timeout waiting for active capacitance update")
+
+        gain = CAPGAIN_LOW if (msg.settings & 1 == 1) else CAPGAIN_HIGH
+        raw = msg.measurement - msg.baseline
+        calibrated = self.__calibrate_capacitance(raw, gain)
+        return raw, calibrated
+
+    def group_capacitance_collector(self):
+        """Return a collector for group capacitance reports
+        """
+        def transform(msg):
+            raw = msg.measurements
+            calibrated = self.__calibrate_group_capacitance(raw)
+            return (raw, calibrated)
+
+        def match(msg):
+            return isinstance(msg, messages.BulkCapacitanceMsg) and msg.group_scan != 0
+
+        return self.purpledrop.get_sync_listener(match, transform)
+
+    def wait_for_group_capacitance(self, timeout=1.0):
+        """Wait for the next group capacitance update to be recieved and return it
+        """
+        match = lambda m: isinstance(m, messages.BulkCapacitanceMsg) and m.group_scan != 0
+        with self.purpledrop.get_sync_listener(match) as listener:
+            msg = listener.next(timeout)
+
+        if msg is None:
+            raise TimeoutError("Timeout waiting for group capacitance update")
+
+        raw = msg.measurements
+        calibrated = self.__calibrate_group_capacitance(raw)
+        return raw, calibrated
+
+    def get_parameter_definitions(self):
+        """Get a list of all of the parameters supported by the PurpleDrop
+
+        Arguments:
+          - None
+        """
+        return {
+            "parameters": self.parameter_list,
+        }
+
+    def get_parameter(self, paramIdx):
+        """Request the current value of a parameter from the device
+
+        Arguments:
+          - paramIdx: The ID of the parameter to request (from the list of
+            parameters provided by 'get_parameter_definition')
+        """
+        self.__ensure_device_connected()
+        req_msg = messages.SetParameterMsg()
+        req_msg.set_param_idx(paramIdx)
+        req_msg.set_param_value_int(0)
+        req_msg.set_write_flag(0)
+        def msg_filter(msg):
+            return isinstance(msg, messages.SetParameterMsg) and msg.param_idx() == paramIdx
+        with self.purpledrop.get_sync_listener(msg_filter=msg_filter) as listener:
+            self.purpledrop.send_message(req_msg)
+            resp = listener.next(timeout=0.5)
+        if resp is None:
+            raise TimeoutError("No response from purpledrop")
+        else:
+            paramDesc = self.__get_parameter_definition(paramIdx)
+            value = None
+            if paramDesc is not None and paramDesc['type'] == 'float':
+                value = resp.param_value_float()
+            else:
+                value = resp.param_value_int()
+            logger.debug(f"get_parameter({paramIdx}) returning {value}")
+            return value
+
+    def set_parameter(self, paramIdx, value):
+        """Set a config parameter
+
+        A special paramIdx value of 0xFFFFFFFF is used to trigger the saving
+        of all parameters to flash.
+
+        Arguments:
+            - paramIdx: The index of the parameter to set (from
+             'get_parameter_definitions')
+            - value: A float or int (based on the definition) with the new
+              value to assign
+        """
+        logging.debug(f"Received set_parameter({paramIdx}, {value})")
+        self.__ensure_device_connected()
+        req_msg = messages.SetParameterMsg()
+        req_msg.set_param_idx(paramIdx)
+        paramDesc = self.__get_parameter_definition(paramIdx)
+        if paramDesc is not None and paramDesc['type'] == 'float':
+            req_msg.set_param_value_float(value)
+        else:
+            req_msg.set_param_value_int(value)
+        req_msg.set_write_flag(1)
+        def msg_filter(msg):
+            return isinstance(msg, messages.SetParameterMsg) and msg.param_idx() == paramIdx
+        with self.purpledrop.get_sync_listener(msg_filter=msg_filter) as listener:
+            self.purpledrop.send_message(req_msg)
+            resp = listener.next(timeout=0.5)
+        if resp is None:
+            raise TimeoutError(f"No response from purpledrop to set parameter ({paramIdx})")
+
+    def get_board_definition(self):
+        """Get electrode board configuratin object
+
+        Arguments: None
+        """
+        return self.board_definition.as_dict()
+
+    def get_bulk_capacitance(self) -> List[float]:
+        """Get the most recent capacitance scan results
+
+        DEPRECATED. Use get_scan_capacitance.
+
+        Arguments: None
+        """
+        logging.debug("Received get_bulk_capacitance")
+        return self.calibrated_scan_capacitance
+
+    def get_scan_capacitance(self) -> Dict[str, Any]:
+        """Get the most recent capacitance scan results
+
+        Arguments: None
+        """
+        return {
+            "raw": self.raw_scan_capacitance,
+            "calibrated": self.calibrated_scan_capacitance
+        }
+
+    def get_group_capacitance(self) -> Dict[str, List[float]]:
+        """Get the latest group scan capacitances
+
+        Arguments: None
+        """
+        return {
+            "raw": self.raw_group_capacitance,
+            "calibrated": self.calibrated_group_capacitance,
+        }
+
+    def get_active_capacitance(self) -> float:
+        """Get the most recent active electrode capacitance
+
+        Arguments: None
+        """
+        logging.debug("Received get_active_capacitance")
+        return self.active_capacitance
+
+    def get_electrode_pins(self):
+        """Get the current state of all electrodes
+
+        Arguments: None
+
+        Returns: List of booleans
+        """
+        logging.debug("Received get_electrode_pins")
+        return self.pin_state.to_dict()
+
+    def set_capacitance_group(self, pins: Sequence[int], group_id: int, setting: int):
+        """Set a capacitance scan group.
+
+        Purpledrop support 5 scan groups. Each group defines a set of electrodes
+        which are measured together after each AC drive cycle.
+
+        Arguments:
+          - pins: A list of pins included in the group (may be empty to clear the group)
+          - group_id: The group number to set (0-4)
+        """
+        self.__ensure_device_connected()
+        if group_id >= 5:
+            raise ValueError("group_id must be < 5")
+
+        # Send message to device to update
+        msg = messages.ElectrodeEnableMsg()
+        msg.group_id = group_id + 100
+        msg.setting = setting
+        msg.values = pinlist2mask(pins)
+        # TODO: Check for ACK; but as of 0.5.1 there is no ACK sent by embedded software to this command
+        #match = lambda m: isinstance(m, messages.CommandAckMsg) and m.acked_id == messages.ElectrodeEnableMsg.ID
+        #listener = self.purpledrop.get_sync_listener(match)
+        self.purpledrop.send_message(msg)
+        # msg = listener.next(timeout=1.0)
+        # listener.unregister()
+        # if msg is None:
+        #     logger.error("Timeout waiting for capacitance group ack")
+        # else:
+        #     logger.warn("Got ack")
+        # Update local state
+        self.pin_state.scan_groups[group_id] = PinState.ScanGroup(pinlist2bool(pins), setting)
+
+        # Send event with new state
+        self.__fire_pinstate_event()
+
+    def set_electrode_pins(self, pins: Sequence[int], group_id: int=0, duty_cycle: int=255):
+        """Set the currently enabled pins
+
+        Specified electrodes will be activated, all other will be deactivated.
+        Providing an empty array will deactivate all electrodes.
+
+        Arguments:
+            - pins: A list of pin numbers to activate
+            - group_id: Which electrode enable group to be set (default: 0)
+                0: Drive group A
+                1: Drive group B
+            - duty_cycle: Duty cycle for the group (0-255)
+        """
+        logging.debug(f"Received set_electrode_pins({pins})")
+
+        self.__ensure_device_connected()
+
+        if group_id < 0 or group_id > 1:
+            raise ValueError(f"group_id={group_id} is invalid. It must be 0 or 1.")
+
+        # Send message to device to update
+        msg = messages.ElectrodeEnableMsg()
+        msg.group_id = group_id
+        msg.setting = duty_cycle
+        msg.values = pinlist2mask(pins)
+
+        match = lambda m: isinstance(m, messages.CommandAckMsg) and m.acked_id == messages.ElectrodeEnableMsg.ID
+        with self.purpledrop.get_sync_listener(match) as listener:
+            self.purpledrop.send_message(msg)
+            ack = listener.next(timeout=0.25)
+        if ack is None:
+            logger.error("Received no ACK for set electrode pins")
+            raise TimeoutError("No ACK received")
+
+        # Update local state
+        self.pin_state.drive_groups[group_id] = PinState.DriveGroup(pinlist2bool(pins), duty_cycle)
+
+        # Send event with new state
+        self.__fire_pinstate_event()
+
+    def set_feedback_command(self, target, mode, input_groups_p_mask, input_groups_n_mask, baseline):
+        """Update feedback control settings
+
+        When enabled, the purpledrop controller will adjust the duty cycle of
+        electrode drive groups based on capacitance measurements.
+
+        Arguments:
+            - target: The controller target in counts
+            - mode:
+                - 0: Disabled
+                - 1: Normal
+                - 2: Differential
+            - input_groups_p_mask: Bit mask indicating which capacitance groups to
+              sum for positive input (e.g. for groups 0 and 2: 5)
+            - input_groups_n_mask: Bit mask for negative input groups (used in differential mode)
+            - baseline: The duty cycle to apply to both drive groups when no error signal is
+              present (0-255)
+        """
+        self.__ensure_device_connected()
+        msg = messages.FeedbackCommandMsg()
+        msg.target = target
+        msg.mode = mode
+        msg.input_groups_p_mask = input_groups_p_mask
+        msg.input_groups_n_mask = input_groups_n_mask
+        msg.baseline = baseline
+        self.purpledrop.send_message(msg)
+
+    def move_drop(self,
+                  start: Sequence[int],
+                  size: Sequence[int],
+                  direction: str) -> MoveDropResult:
+        """Execute a drop move sequence
+
+        Arguments:
+            - start: A list -- [x, y] -- specifying the top-left corner of the current drop location
+            - size: A list -- [width, height] -- specifying the size of the drop to be moved
+            - direction: One of, "Up", "Down", "Left", "Right"
+        """
+        logging.debug(f"Received move_drop({start}, {size}, {direction})")
+        self.__ensure_device_connected()
+        return move_drop(self, start, size, direction)
+
+    def move_drops(self, moves: List[Dict]) -> List[MoveDropResult]:
+        """Execute a movement of 1-5 drops concurrently
+
+        Uses capacitance feedback to determine when drop movement has completed.
+
+        Up to five movement commands can be executed simultaneously. This method
+        returns when all movements are completed. A list of MoveDropResults is
+        returned; one for each move command.
+
+        Arguments:
+            - moves: A list of move command objects
+
+        A move command object can contain the following fields:
+            - start_pins: Required. A list of pins which make up the drop starting electrodes.
+            - end_pins: Required. A list of pisn which make up the drop ending electrodes.
+            - timeout: Optional. Move timeout in seconds.
+            - post_capture_time: Optional. Amount of time to capture capacitance data after
+                    move is completed.
+            - low_gain: Optional. Boolean. It true, low gain will be used for capacitance
+                    measurement for this drop.
+            - threshold: Optional. Sets the capacitance required for move to be complete,
+                    as fraction of initial capacitance. If not provided, a default
+                    is used.
+        """
+        logging.debug(f"Received move_drops({moves})")
+        self.__ensure_device_connected()
+        return move_drops(self, moves)
+
+    def get_temperatures(self) -> Sequence[float]:
+        """Returns an array of all temperature sensor measurements in degrees C
+
+        Arguments: None
+        """
+        logging.debug("Received get_temperatures")
+        return self.temperatures
+
+    def set_pwm_duty_cycle(self, chan: int, duty_cycle: float):
+        """Set the PWM output duty cycle for a single channel
+
+        Arguments:
+            - chan: An integer specifying the channel to set
+            - duty_cycle: A float specifying the duty cycle in range [0, 1.0]
+        """
+        self.__ensure_device_connected()
+        logging.debug(f"Received set_pwm_duty_cycle({chan}, {duty_cycle})")
+        self.duty_cycles[chan] = duty_cycle
+        msg = messages.SetPwmMsg()
+        msg.chan = chan
+        msg.duty_cycle = duty_cycle
+        self.purpledrop.send_message(msg)
+
+    def get_hv_supply_voltage(self):
+        """Return the latest high voltage rail measurement
+
+        Arguments: None
+
+        Returns: A float, in volts
+        """
+        logging.debug("Received get_hv_supply_voltage")
+        return self.hv_supply_voltage
+
+    def calibrate_capacitance_offset(self):
+        """Request a calibration of the capacitance measurement zero offset
+
+        Arguments: None
+
+        Returns: None
+        """
+        self.__ensure_device_connected()
+        msg = messages.CalibrateCommandMsg()
+        msg.command = messages.CalibrateCommandMsg.CAP_OFFSET_CMD
+        self.purpledrop.send_message(msg)
+
+    def get_device_info(self):
+        """Gets information about the connected purpledrop device
+
+        Arguments: None
+
+        Returns: Object with the following fields:
+          - connected: boolean indicating if a device is currently connected
+          - serial_number: The serial number of the connected device
+          - software_version: The software version string of the connected device
+        """
+        serial_number = self.purpledrop.connected_serial_number()
+        if serial_number is None:
+            return {
+                'connected': False,
+                'serial_number': '',
+                'software_version': ''
+            }
+        else:
+            software_version = self.get_software_version()
+            return {
+                'connected': True,
+                'serial_number': serial_number,
+                'software_version': software_version
+            }
+
+    def read_gpio(self, gpio_num):
+        """Reads the current input value of a GPIO pin
+
+        Arguments:
+          - gpio_num:  The ID of the GPIO to read
+
+        Returns: A bool
+        """
+        self.__ensure_device_connected()
+        msg = messages.GpioControlMsg()
+
+        msg.pin = gpio_num
+        msg.read = True
+
+        with self.purpledrop.get_sync_listener(msg_filter=messages.GpioControlMsg) as listener:
+            self.purpledrop.send_message(msg)
+            rxmsg  = listener.next(0.5)
+        if rxmsg is None:
+            raise TimeoutError("No response from purpledrop to GPIO read request")
+        else:
+            return rxmsg.value
+
+    def write_gpio(self, gpio_num, value, output_enable):
+        """Set the output state of a GPIO pin
+
+        Arguments:
+          - gpio_num: The ID of the GPIO to set
+          - value: The output value (boolean)
+          - output_enable: Set the GPIO as an output (true) or input (false)
+
+        Returns:
+          - The value read on the GPIO (bool)
+        """
+        self.__ensure_device_connected()
+        msg = messages.GpioControlMsg()
+
+        msg.pin = gpio_num
+        msg.read = False
+        msg.value = value
+        msg.output_enable = output_enable
+
+        with self.purpledrop.get_sync_listener(msg_filter=messages.GpioControlMsg) as listener:
+            self.purpledrop.send_message(msg)
+            rxmsg = listener.next(0.5)
+        if rxmsg is None:
+            raise TimeoutError("No response from purpledrop to GPIO read request")
+        else:
+            return rxmsg.value
+
+    def set_electrode_calibration(self, voltage: float, offsets: Sequence[int]):
+        """Set the capacitance offset for each electrode
+
+        Provides a table of values to be subtracted for each electrode to
+        compensate for parasitic capacitance of the electrode. Values are
+        measured at high gain, with no liquid on the device, at a certain
+        voltage.
+
+        These values will be adjusted for changes in voltage from the measured
+        voltage, and for low gain when applied by the purpledrop.
+
+        Arguments:
+          - voltage: The voltage setting at which the offsets were measured
+          - offsets: A list of 128 16-bit values to be subtracted
+
+        Returns: None
+        """
+        self.__ensure_device_connected()
+        offsets = list(map(int, offsets))
+        table = struct.pack("<f128H", voltage, *offsets)
+
+        tx_pos = 0
+        while tx_pos < len(table):
+            tx_size = min(64, len(table) - tx_pos)
+            msg = messages.DataBlobMsg()
+            msg.blob_id = msg.OFFSET_CALIBRATION_ID
+            msg.chunk_index = tx_pos
+            msg.payload_size = tx_size
+            msg.payload = table[tx_pos:tx_pos+tx_size]
+            tx_pos += tx_size
+            with self.purpledrop.get_sync_listener(messages.CommandAckMsg) as listener:
+                self.purpledrop.send_message(msg)
+                ack = listener.next(timeout=0.5)
+            if ack is None:
+                raise TimeoutError("No ACK while setting electrode calibration")
+
+    def set_scan_gains(self, gains: Optional[Sequence[bool]]=None):
+        """Set the gains used for capacitance scan measurement
+
+        If no gains argument is provided, scan gains will be set based on
+        oversized electrodes defined in the board definition file.
+
+        Arguments:
+          - gains: A list of 128 booleans, true indicating that an electrode
+            should be scanned with low gain
+        """
+        self.__ensure_device_connected()
+        if gains is not None:
+            if len(gains) != 128:
+                raise ValueError("Scan gains must have 128 values")
+            # Make sure they are all convertible to bool
+            gains = [bool(x) for x in gains]
+        self.__set_scan_gains(gains)
+
+    def get_scan_gains(self) -> List[bool]:
+        """Return the current scan gain settings
+        """
+        return [x == CAPGAIN_LOW for x in self.scan_gains]

--- a/purpledrop/controller.py
+++ b/purpledrop/controller.py
@@ -23,6 +23,7 @@ logger = logging.getLogger("controller")
 # Versions of purpledrop software supported by this driver
 SUPPORTED_VERSIONS = [
     "v0.5.*",
+    "Simulated"
 ]
 
 def validate_version(v):

--- a/purpledrop/exceptions.py
+++ b/purpledrop/exceptions.py
@@ -1,0 +1,5 @@
+class NoDeviceException(Exception):
+    """Raised when an operation requiring an attached purpledrop is attempted
+    but not device is currently connected
+    """
+    pass

--- a/purpledrop/messages.py
+++ b/purpledrop/messages.py
@@ -39,12 +39,11 @@ class ActiveCapacitanceMsg(PurpleDropMessage):
     ID = 3
 
     def __init__(self, fill_data: Optional[bytes]=None):
+        self.baseline = 0
+        self.measurement = 0
+        self.settings = 0
         if fill_data is not None:
             self.fill(fill_data)
-        else:
-            self.baseline = 0
-            self.measurement = 0
-            self.settings = 0
 
     @staticmethod
     def predictSize(buf: bytes) -> int:
@@ -60,13 +59,12 @@ class BulkCapacitanceMsg(PurpleDropMessage):
     ID = 2
 
     def __init__(self, fill_data: Optional[bytes]=None):
+        self.group_scan = 0
+        self.start_index = 0
+        self.count = 0
+        self.measurements: Sequence[int] = []
         if fill_data is not None:
             self.fill(fill_data)
-        else:
-            self.group_scan = 0
-            self.start_index = 0
-            self.count = 0
-            self.measurements: Sequence[int] = []
 
     @staticmethod
     def predictSize(buf: bytes) -> int:
@@ -109,10 +107,9 @@ class CommandAckMsg(PurpleDropMessage):
     ID = 4
 
     def __init__(self, fill_data: Optional[bytes]=None):
+        self.acked_id = 0
         if fill_data is not None:
             self.fill(fill_data)
-        else:
-            self.acked_id = 0
 
     @staticmethod
     def predictSize(buf: bytes) -> int:
@@ -134,13 +131,12 @@ class DataBlobMsg(PurpleDropMessage):
     OFFSET_CALIBRATION_ID = 1
 
     def __init__(self, fill_data: Optional[bytes]=None):
+        self.blob_id = 0
+        self.chunk_index = 0
+        self.payload_size = 0
+        self.payload = bytes([])
         if fill_data is not None:
             self.fill(fill_data)
-        else:
-            self.blob_id = 0
-            self.chunk_index = 0
-            self.payload_size = 0
-            self.payload = bytes([])
 
     @staticmethod
     def predictSize(buf: bytes) -> int:
@@ -169,11 +165,10 @@ class DutyCycleUpdatedMsg(PurpleDropMessage):
     ID = 15
 
     def __init__(self, fill_data: Optional[bytes]=None):
+        self.duty_cycle_A = 0
+        self.duty_cycle_B = 0
         if(fill_data):
             self.fill(fill_data)
-        else:
-            self.duty_cycle_A = 0
-            self.duty_cycle_B = 0
 
     @staticmethod
     def predictSize(buf: bytes) -> int:
@@ -195,14 +190,13 @@ class FeedbackCommandMsg(PurpleDropMessage):
     DIFFERENTIAL = 2
 
     def __init__(self, fill_data: Optional[bytes]=None):
+        self.target = 0.0
+        self.mode = 0
+        self.input_groups_p_mask = 0
+        self.input_groups_n_mask = 0
+        self.baseline = 0
         if(fill_data):
             raise RuntimeError("Receiving FeedbackCommandMsg unimplemented")
-        else:
-            self.target = 0.0
-            self.mode = 0
-            self.input_groups_p_mask = 0
-            self.input_groups_n_mask = 0
-            self.baseline = 0
 
     def to_bytes(self) -> bytes:
         return struct.pack(
@@ -415,11 +409,10 @@ class SetPwmMsg(PurpleDropMessage):
     ID = 9
 
     def __init__(self, fill_data: Optional[bytes]=None):
+        self.chan = 0
+        self.duty_cycle = 0.0
         if fill_data is not None:
             self.fill(fill_data)
-        else:
-            self.chan = 0
-            self.duty_cycle = 0.0
 
     def fill(self, buf: bytes):
         raise RuntimeError("Not implemented")
@@ -431,10 +424,9 @@ class TemperatureMsg(PurpleDropMessage):
     ID = 7
 
     def __init__(self, fill_data: Optional[bytes]=None):
+        self.measurements: Sequence[int] = []
         if fill_data is not None:
             self.fill(fill_data)
-        else:
-            self.measurements: Sequence[int] = []
 
     @staticmethod
     def predictSize(buf: bytes) -> int:
@@ -463,19 +455,14 @@ class HvRegulatorMsg(PurpleDropMessage):
     ID = 8
 
     def __init__(self, fill_data: Optional[bytes]=None):
+        self.voltage = 0.0
+        self.v_target_out = 0
         if fill_data is not None:
             self.fill(fill_data)
-        else:
-            self.voltage = 0.0
-            self.v_target_out = 0
 
     @staticmethod
     def predictSize(buf: bytes) -> int:
         return 7
-        if(len(buf) < 2):
-            return 0
-        else:
-            return buf[1]*2 + 2
 
     def fill(self, buf: bytes):
         if len(buf) < 7:

--- a/purpledrop/move_drop.py
+++ b/purpledrop/move_drop.py
@@ -1,8 +1,20 @@
+from functools import reduce
+import numpy as np
+import schema
 import time
-from typing import Sequence
+from typing import Dict, List, Sequence, Set
 
 import purpledrop.messages as messages
 from purpledrop.electrode_board import Layout
+
+MoveCommandSchema = schema.Schema({
+    'start_pins': schema.And([int], len),
+    'end_pins': schema.And([int], len),
+    schema.Optional('timeout'): schema.Use(float),
+    schema.Optional('post_capture_time'): schema.Use(float),
+    schema.Optional('low_gain'): bool,
+    schema.Optional('threshold'): schema.Use(float)
+    })
 
 class MoveDropResult(dict):
     """Inherits from dict for JSON serializability
@@ -24,7 +36,7 @@ class MoveDropClosedLoopResult(dict):
                     time_series: Sequence[float],
                     capacitance_series: Sequence[float]):
         dict.__init__(
-            self, 
+            self,
             pre_capacitance=pre_capacitance,
             post_capacitance=post_capacitance,
             time_series=time_series,
@@ -35,7 +47,7 @@ class Location(object):
     def __init__(self, coords: Sequence[int]):
         self.x = coords[0]
         self.y = coords[1]
-    
+
     def __getattr__(self, idx):
         if idx == 0:
             return x
@@ -69,7 +81,7 @@ class Rectangle(object):
 
     def move_one(self, dir):
         return Rectangle(self.location.move_one(dir), self.dimensions)
-    
+
     def grid_locations(self):
         locs = []
         for x in range(self.dimensions[0]):
@@ -77,90 +89,239 @@ class Rectangle(object):
                 locs.append((x + self.location.x, y + self.location.y))
         return locs
 
-def move_drop(purpledrop, start, size, direction, post_capture_time=0.25):
-    initial_rect = Rectangle(Location(start), size)
-    final_rect = initial_rect.move_one(direction)
-
-    def wait_for(msgtype, timeout):
-        start = time.time()
-        while time.time() - start < timeout:
-            msg = listener.wait(timeout=0.1)
-            if msg is not None and isinstance(msg, msgtype):
-                return msg
-        return None
-
+def _set_pins_with_ack(purpledrop, pins):
     def msg_filter(msg):
-        if isinstance(msg, messages.ActiveCapacitanceMsg):
-            return True
         if isinstance(msg, messages.CommandAckMsg) and \
             msg.acked_id == messages.ElectrodeEnableMsg.ID:
             return True
         return False
-    
-    def set_pins(pins):
+
+    with purpledrop.purpledrop.get_sync_listener(msg_filter) as listener:
         retries = 8
         while retries > 0:
             purpledrop.set_electrode_pins(pins)
             # Read up to ACK of set pins
-            msg = wait_for(messages.CommandAckMsg, 0.2)
+            msg = listener.next(timeout=0.25)
             if msg is not None:
                 return msg
             retries -= 1
-        raise RuntimeError("Timed out waiting for electrode command ACK")
+    raise RuntimeError("Timed out waiting for electrode command ACK")
 
-    # Create a listener which will queue all incoming messages that match
-    # our filter. We can expect to get all messages in the order they were
-    # received
-    listener = purpledrop.purpledrop.get_sync_listener(msg_filter)
+def move_drop(purpledrop, start, size, direction, post_capture_time=0.25):
+    initial_rect = Rectangle(Location(start), size)
+    final_rect = initial_rect.move_one(direction)
 
     layout = Layout(purpledrop.get_board_definition()['layout'])
     pins = [layout.grid_location_to_pin(loc[0], loc[1]) for loc in initial_rect.grid_locations()]
     if None in pins:
         raise ValueError("Invalid move coordinates")
-    set_pins(pins)
 
-    msg = wait_for(messages.ActiveCapacitanceMsg, 2.0)
-    if msg is None:
-        raise RuntimeError("Timed out waiting for first capacitance message")
+    # Ensure drive group B is off
+    purpledrop.set_electrode_pins([], 1)
 
-    pre_capacitance = msg.measurement - msg.baseline
+    _set_pins_with_ack(purpledrop, pins)
 
-    pins = [layout.grid_location_to_pin(loc[0], loc[1]) for loc in final_rect.grid_locations()]
-    if None in pins:
-        raise ValueError("Invalid move destination")
-    set_pins(pins)
+    # Create a listener which will queue all incoming messages that match
+    # our filter. We can expect to get all messages in the order they were
+    # received
+    with purpledrop.active_capacitance_collector() as collector:
+        _raw, calibrated = purpledrop.wait_for_active_capacitance(timeout=2.0)
+        pre_capacitance = calibrated
 
-    MOVE_THRESHOLD = 0.8 * pre_capacitance
-    MOVE_TIMEOUT = 5.0
-    time_series = []
-    cap_series = []
-    t = 0.0
-    start_time = time.time()
-    end_time = start_time + MOVE_TIMEOUT
-    detected = False
-    while time.time() < end_time:
-        msg = wait_for(messages.ActiveCapacitanceMsg, 0.5)
-        if msg is None:
-            raise RuntimeError("Timed out waiting for capacitance message")
-        time_series.append(t)
-        x = msg.measurement - msg.baseline
-        cap_series.append(x)
-        # For now, just assume the samples are periodic at 2ms to create a time vector
-        # At some point, they should come with their own timestamps
-        t += 2e-3
-        if x >= MOVE_THRESHOLD and not detected:
-            # keep capturing for a while longer after hitting the target threshold
-            end_time = time.time() + post_capture_time
-            detected = True
+        pins = [layout.grid_location_to_pin(loc[0], loc[1]) for loc in final_rect.grid_locations()]
+        if None in pins:
+            raise ValueError("Invalid move destination")
+        _set_pins_with_ack(purpledrop, pins)
 
-    post_capacitance = cap_series[-1]
+        MOVE_THRESHOLD = 0.8 * pre_capacitance
+        MOVE_TIMEOUT = 5.0
+        time_series = []
+        cap_series = []
+        t = 0.0
+        start_time = time.time()
+        end_time = start_time + MOVE_TIMEOUT
+        detected = False
 
-    success = post_capacitance > MOVE_THRESHOLD
-    closed_loop_result = MoveDropClosedLoopResult(
-        pre_capacitance,
-        post_capacitance,
-        time_series,
-        cap_series
-    )
+        # Flush received samples so we know we've consumed all samples from the
+        # starting pins
+        while not collector.empty():
+            measurement = collector.next(timeout=1.0)
+            if measurement is None:
+                raise TimeoutError("Timeout waiting for capacitance report")
+            _raw, calibrated = measurement
+            time_series.append(t)
+            cap_series.append(calibrated)
+            t += 2e-3
 
-    return MoveDropResult(success, True, closed_loop_result)
+        while time.time() < end_time:
+            measurement = collector.next(timeout=1.0)
+            if measurement is None:
+                raise RuntimeError("Timed out waiting for capacitance message")
+            _raw, calibrated = measurement
+            time_series.append(t)
+            cap_series.append(calibrated)
+            # For now, assume the samples are periodic at 2ms to create a time vector
+            # At some point, they should come with their own timestamps
+            t += 2e-3
+            if calibrated >= MOVE_THRESHOLD and not detected:
+                # keep capturing for a while longer after hitting the target threshold
+                end_time = time.time() + post_capture_time
+                detected = True
+
+        post_capacitance = cap_series[-1]
+
+        closed_loop_result = MoveDropClosedLoopResult(
+            pre_capacitance,
+            post_capacitance,
+            time_series,
+            cap_series
+        )
+
+        return MoveDropResult(detected, True, closed_loop_result)
+
+def move_drops(purpledrop, moves: List[Dict]) -> List[MoveDropResult]:
+    """Moves multiple drops concurrently
+
+    This method can move up to 5 concurrent drops. This limits is set by the
+    number of capacitance scan groups supported by the Purpledrop.
+
+    Args:
+        moves: A list of move command argument dicts, of the form shown below
+
+    Returns:
+        A list of MoveDropResult objects, one for each move argument
+
+    A move argument object has four fields:
+        "start_pins": List of electrode pins on which the drop currently reside.
+                      These are used to measure the initial capacitance.
+        "end_pins": List of electrode pins onto which the drop is to be moved.
+        "timeout": Optional. Move timeout in seconds. If not provided, a default is used.
+        "post_capture_time": Optional. Amount of time to capture capacitance data after
+                             move is completed. If not provided, a default is used.
+        "low_gain": Optional. If set true, low gain will be used for capacitance
+                    measurement.
+        "threshold": Optional. Sets the capacitance required for move to be complete,
+                     as fraction of initial capacitance. If not provided, a default
+                     is used.
+
+    Example move object:
+
+        {
+            "start_pins": [3, 4, 5, 6],
+            "end_pins": [5, 6, 7, 8],
+            "timeout": 5.0,
+            "post_capture_time": 0.25,
+            "low_gain": False,
+        }
+
+    """
+
+    MAX_DROPS = 5
+    DEFAULT_TIMEOUT = 10.0
+    DEFAULT_THRESHOLD = 0.8
+    DEFAULT_POST_CAPTURE_TIME = 0.25
+
+    # Validate input arguments: must be a list of objects matching MoveCommandSchema
+    # Will raise on failure
+    moves = schema.Schema([MoveCommandSchema]).validate(moves)
+
+    if len(moves) > MAX_DROPS:
+        raise ValueError(f"Cannot move more than {MAX_DROPS} concurrently")
+
+    def group_scan_filter(msg):
+        if isinstance(msg, messages.BulkCapacitanceMsg) and msg.group_scan != 0:
+            return True
+        return False
+
+    # Collect all of the pins together from all drops
+    start_pins: List[int] = list(reduce(lambda a,b: set(a).union(b), [m['start_pins'] for m in moves], set()))
+    end_pins: List[int] = list(reduce(lambda a,b: set(a).union(b), [m['end_pins'] for m in moves], set()))
+
+    # Ensure drive group B is off
+    purpledrop.set_electrode_pins([], 1)
+
+    # Setup capacitance groups
+    for i, m in enumerate(moves):
+        time.sleep(0.02) # hack to avoid overflowing receive buffer
+        # The delay can be removed embedded software supports acking and/or
+        # gets a longer rx buffer
+        gain_setting = int(m.get('low_gain', False))
+        purpledrop.set_capacitance_group(m['start_pins'], i, gain_setting)
+
+    # Enable the start pins
+    # This makes sure drops are properly located, and allows for most reliable
+    # initial capacitance measurement
+    _set_pins_with_ack(purpledrop, start_pins)
+
+    n_drops = len(moves)
+    cap_series: List[List[float]] = []
+
+    # Begin collecting samples of group capacitance
+    with purpledrop.group_capacitance_collector() as collector:
+
+        # Read group capacitance to get initial values
+        _raw, initial_cap = purpledrop.wait_for_group_capacitance(timeout=2.0)
+
+        # Change capacitance groups to measure destination electrodes
+        for i, m in enumerate(moves):
+            time.sleep(0.02) # hack to avoid overflowing receive buffer
+            gain_setting = int(m.get('low_gain', False))
+            purpledrop.set_capacitance_group(m['end_pins'], i, gain_setting)
+
+        # Enable the destination electrodes
+        _set_pins_with_ack(purpledrop, end_pins)
+
+        # Flush received samples so we know we've consumed all samples from the
+        # starting pins
+        while not collector.empty():
+            measurement = collector.next(timeout=2.0)
+            if measurement is None:
+                raise TimeoutError("Timeout waiting for group capacitance report")
+            _raw, calibrated = measurement
+            cap_series.append(calibrated)
+
+        start_time = time.time()
+        end_times = [start_time + m.get('timeout', DEFAULT_TIMEOUT) for m in moves]
+        last_sample_index = [0] * n_drops
+        finish_thresholds = [m.get('threshold', DEFAULT_THRESHOLD) * initial_cap[i] for i, m in enumerate(moves)]
+        success_flags = [False] * n_drops
+        n_running = n_drops
+
+        while n_running > 0:
+            measurement = collector.next(timeout=2.0)
+            if measurement is None:
+                raise TimeoutError("Timeout waiting for group capacitance report")
+            _raw, calibrated = measurement
+            cap_series.append(calibrated)
+            if collector.empty():
+                curtime = time.time()
+                for i in range(n_drops):
+                    if last_sample_index[i] != 0:
+                        # Drop previously finished
+                        continue
+                    if not success_flags[i] and calibrated[i] >= finish_thresholds[i]:
+                        success_flags[i] = True
+                        # keep capturing for a while longer after hitting the target threshold
+                        end_times[i] = curtime + moves[i].get('post_capture_time', DEFAULT_POST_CAPTURE_TIME)
+                    if curtime > end_times[i]:
+                        # This drop is now finished
+                        last_sample_index[i] = len(cap_series)
+                        n_running -= 1
+
+        results = []
+        for i in range(n_drops):
+            cap_data = [x[i] for x in cap_series[:last_sample_index[i]]]
+            final_cap = 0.0
+            if len(cap_data) > 0:
+                final_cap = cap_data[-1]
+            # Assuming known sample period of 2ms
+            time_series = np.arange(0, len(cap_data) * 2e-3, 2e-3).tolist()
+            closed_loop_result = MoveDropClosedLoopResult(
+                initial_cap[i],
+                final_cap,
+                time_series,
+                cap_data)
+            results.append(MoveDropResult(success_flags[i], True, closed_loop_result))
+
+        return results
+

--- a/purpledrop/pdcam/video.py
+++ b/purpledrop/pdcam/video.py
@@ -106,7 +106,6 @@ class Video(object):
             camera.resolution = (self.WIDTH, self.HEIGHT)
             camera.framerate = 30
             camera.iso = 60
-            camera.start_preview()
 
             time.sleep(2)
             gains = camera.awb_gains

--- a/purpledrop/purpledrop.py
+++ b/purpledrop/purpledrop.py
@@ -1,60 +1,25 @@
 """Low-level driver for communicating with PurpleDrop via serial messages
 """
+from abc import abstractmethod, ABC
+import gevent
 import inspect
-import fnmatch
 import logging
 import queue
-import struct
 import serial
 import serial.tools.list_ports
-import sys
-import threading
-import time
-from typing import Any, AnyStr, Callable, Dict, List, Optional, Sequence
+from typing import Any, AnyStr, Callable, Dict, List, Optional
 
-from purpledrop.calibration import ElectrodeOffsetCalibration
-from purpledrop.electrode_board import Board
-import purpledrop.messages as messages
-import purpledrop.protobuf.messages_pb2 as messages_pb2
-from .messages import PurpleDropMessage, ElectrodeEnableMsg, SetPwmMsg
+from .messages import PurpleDropMessage
 from .message_framer import MessageFramer, serialize
-from .move_drop import move_drop, MoveDropResult
+
 
 logger = logging.getLogger("purpledrop")
-
-# Versions of purpledrop software supported by this driver
-SUPPORTED_VERSIONS = [
-    "v0.5.*",
-]
 
 # List of USB VID/PID pairs which will be recognized as a purpledrop
 PURPLEDROP_VIDPIDS = [
     (0x02dd, 0x7da3),
     (0x1209, 0xCCAA),
 ]
-
-def pinlist2bool(pins):
-    pin_state = [False] * N_PINS
-
-    for p in pins:
-        if(p >= N_PINS):
-            raise ValueError(f"Pin {p} is invalid. Must be < {N_PINS}")
-        pin_state[p] = True
-    return pin_state
-
-def pinlist2mask(pins):
-    mask = [0] * int(((N_PINS + 7) / 8))
-    for p in pins:
-        word = int(p / 8)
-        bit = p % 8
-        mask[word] |= (1<<bit)
-    return mask
-
-def validate_version(v):
-    for pattern in SUPPORTED_VERSIONS:
-        if fnmatch.fnmatch(v, pattern):
-            return True
-    return False
 
 def resolve_msg_filter(filt):
     """If the filter provided is a message type, then create a filter which returns
@@ -75,17 +40,10 @@ def list_purpledrop_devices() -> List[serial.tools.list_ports_common.ListPortInf
     selected_devices = [x for x in devices if (x.vid, x.pid) in PURPLEDROP_VIDPIDS]
     return selected_devices
 
-def get_pb_timestamp():
-    """Get a protobuf timestamp for the current system time
-    """
-    time_f = time.time()
-    ts = messages_pb2.Timestamp()
-    ts.seconds = int(time_f)
-    ts.nanos = int((time_f % 1) * 1e9)
-    return ts
+
 class PurpleDropRxThread(object):
     def __init__(self, port: serial.Serial, callback: Callable[[PurpleDropMessage], None]=None):
-        self._thread = threading.Thread(target=self.run, name="PurpleDrop Rx", daemon=True)
+        self._thread = gevent.Greenlet(self.run)
         self._ser = port
         self._framer = MessageFramer(PurpleDropMessage.predictSize)
         self._callback = callback
@@ -117,7 +75,6 @@ class PurpleDropRxThread(object):
                         except Exception as e:
                             logger.exception(e)
 
-
     def set_callback(self, callback):
         self._callback = callback
 
@@ -131,14 +88,38 @@ class SyncListener(object):
             if self.filter is None or self.filter(msg):
                 self.fifo.put(msg)
 
-    def __init__(self, owner, msg_filter=None):
-        self.owner = owner
+    def __init__(self,
+                 purpledrop: 'PurpleDropDevice',
+                 msg_filter: Callable[[PurpleDropMessage], bool]=None,
+                 transform: Callable[[PurpleDropMessage], Any]=None):
+        """Create a listener object
+
+        The SyncListener can be used in a with statement, e.g.
+
+            with purpledrop.get_sync_listener(filter) as listener:
+                msg = listener.next()
+
+        Alternatively, you can call the `register` method to begin listening for
+        messages, and `unregister` to stop. However, be sure to always call
+        `unregister` when finished, or else you will create a memory leak and
+        performance hit as incoming messages will continue to be passed to the
+        listener queue until it is unregistered.
+        """
+        self.owner = purpledrop
         self.filter = resolve_msg_filter(msg_filter)
-        self.fifo = queue.Queue()
+        self.fifo: queue.Queue[PurpleDropMessage] = queue.Queue()
+        self.transform = transform
         self.delegate = self.MsgDelegate(self.filter, self.fifo)
 
-    def __del__(self):
+    def __enter__(self):
+        self.register()
+        return self
+
+    def __exit__(self, type, value, traceback):
         self.unregister()
+
+    def register(self):
+        self.owner.register_listener(self.delegate)
 
     def unregister(self):
         self.owner.unregister_listener(self.delegate)
@@ -146,9 +127,15 @@ class SyncListener(object):
     def get_msg_handler(self):
         return self.delegate
 
-    def wait(self, timeout: Optional[float]=None) -> Optional[PurpleDropMessage]:
+    def empty(self) -> bool:
+        return self.fifo.empty()
+
+    def next(self, timeout: Optional[float]=None) -> Optional[PurpleDropMessage]:
         try:
-            return self.fifo.get(timeout=timeout)
+            msg = self.fifo.get(timeout=timeout)
+            if self.transform is not None:
+                msg = self.transform(msg)
+            return msg
         except queue.Empty:
             return None
 
@@ -175,7 +162,66 @@ class AsyncListener(object):
     def get_msg_handler(self):
         return self.delegate
 
-class PurpleDropDevice():
+class PurpleDropDevice(ABC):
+    """Abstract class for a purple drop device
+    """
+    def __init__(self):
+        self.lock = gevent.lock.RLock()
+        self.listeners = []
+        self.__connected_callbacks: List[Callable] = []
+        self.__disconnected_callbacks: List[Callable] = []
+
+    def register_connected_callback(self, callback: Callable):
+        self.__connected_callbacks.append(callback)
+
+    def register_disconnected_callback(self, callback: Callable):
+        self.__disconnected_callbacks.append(callback)
+
+    def on_connected(self):
+        for cb in self.__connected_callbacks:
+            cb()
+
+    def on_disconnected(self):
+        for cb in self.__disconnected_callbacks:
+            cb()
+
+    def register_listener(self, listener):
+        with self.lock:
+            self.listeners.append(listener)
+
+    def unregister_listener(self, listener):
+        with self.lock:
+            if listener in self.listeners:
+                self.listeners.remove(listener)
+
+    def get_sync_listener(self, msg_filter=None, transform=None) -> SyncListener:
+        return SyncListener(purpledrop=self, msg_filter=msg_filter, transform=transform)
+
+    def get_async_listener(self, callback, msg_filter=None) -> AsyncListener:
+        new_listener = AsyncListener(owner=self, callback=callback, msg_filter=msg_filter)
+        with self.lock:
+            self.listeners.append(new_listener.get_msg_handler())
+        return new_listener
+
+    def on_message_received(self, msg):
+        with self.lock:
+            for handler in self.listeners:
+                handler(msg)
+
+    def connected_serial_number(self) -> Optional[str]:
+        """Returns the serial number of the connected device
+        """
+        return "NA"
+
+    @abstractmethod
+    def send_message(self, msg: PurpleDropMessage):
+        pass
+
+    @abstractmethod
+    def connected(self) -> bool:
+        pass
+
+class SerialPurpleDropDevice(PurpleDropDevice):
     """Low level messaging for controlling a PurpleDrop via a serial port
 
     Use `list_purpledrop_devices()` to find devices based on their USB VID/PID
@@ -187,29 +233,19 @@ class PurpleDropDevice():
     functionality and matches the JSON-RPC methods provided by `pd-server`.
     """
     def __init__(self, port=None):
+        super().__init__()
         self._rx_thread = None
         self._ser = None
-        self.lock = threading.Lock()
-        self.listeners = []
-        self.__connected_callbacks: List[Callable] = []
-        self.__disconnected_callbacks: List[Callable] = []
 
         if port is not None:
             self.open(port)
 
-    def register_connected_callback(self, callback: Callable):
-        self.__connected_callbacks.append(callback)
-
-    def register_disconnected_callback(self, callback: Callable):
-        self.__disconnected_callbacks.append(callback)
-
     def open(self, port):
         logger.debug(f"PurpleDropDevice: opening {port}")
         self._ser = serial.Serial(port, timeout=0.01, write_timeout=0.5)
-        self._rx_thread = PurpleDropRxThread(self._ser, callback=self.message_callback)
+        self._rx_thread = PurpleDropRxThread(self._ser, callback=self.on_message_received)
         self._rx_thread.start()
-        for cb in self.__connected_callbacks:
-            cb()
+        self.on_connected()
 
     def close(self):
         logger.debug("Closing PurpleDropDevice")
@@ -218,41 +254,18 @@ class PurpleDropDevice():
             self._rx_thread.join()
         if self._ser is not None:
             self._ser.close()
-            for cb in self.__disconnected_callbacks:
-                cb()
+            self.on_disconnected()
 
     def connected(self):
         return self._ser is not None and \
             self._rx_thread is not None and \
             self._rx_thread.running
 
-    def unregister_listener(self, listener):
-        with self.lock:
-            self.listeners.remove(listener)
-
-    def get_sync_listener(self, msg_filter=None) -> SyncListener:
-        new_listener = SyncListener(owner=self, msg_filter=msg_filter)
-        with self.lock:
-            self.listeners.append(new_listener.get_msg_handler())
-        return new_listener
-
-    def get_async_listener(self, callback, msg_filter=None) -> AsyncListener:
-        new_listener = AsyncListener(owner=self, callback=callback, msg_filter=msg_filter)
-        with self.lock:
-            self.listeners.append(new_listener.get_msg_handler())
-        return new_listener
-
     def send_message(self, msg: PurpleDropMessage):
         tx_bytes = serialize(msg.to_bytes())
         with self.lock:
             self._ser.write(tx_bytes)
-
-    def message_callback(self, msg: PurpleDropMessage):
-        with self.lock:
-            for handler in self.listeners:
-                handler(msg)
-
-class PersistentPurpleDropDevice(PurpleDropDevice):
+class PersistentPurpleDropDevice(SerialPurpleDropDevice):
     """A wrapper for PurpleDropDevice that transparently tries to
     connect/reconnect to a device.
 
@@ -264,10 +277,7 @@ class PersistentPurpleDropDevice(PurpleDropDevice):
         super().__init__()
         self.target_serial_number: Optional[str] = serial_number
         self.device_info: Optional[Any] = None
-        self.__thread = threading.Thread(
-            name="PersistentPurpleDropDevice Monitor",
-            target=self.__thread_entry,
-            daemon=True)
+        self.__thread = gevent.Greenlet(self.__thread_entry)
         self.__thread.start()
 
     def connected_serial_number(self) -> Optional[str]:
@@ -312,761 +322,5 @@ class PersistentPurpleDropDevice(PurpleDropDevice):
                     status = False
                 logger.debug("Attempting to connect to purpledrop")
                 status = self.__try_to_connect()
-            time.sleep(5.0)
+            gevent.sleep(5.0)
 
-N_PINS = 128
-N_MASK_BYTES = 16
-
-# Compute coefficients to convert integrated voltage to integrated charge
-# These values are nominal calculated values, not calibrated in any way
-# Divide by the voltage to get farads. 
-# First stage gain
-GAIN1 = 2.0
-# Integrator gain (Vout per integrated input V*s)
-GAIN2 = 25000.0
-# Output stage gain
-GAIN3 = 22.36
-# Sense resistances for high/low gain
-RLOW = 33.0
-RHIGH = 220.0
-CAPGAIN_HIGH = RHIGH * GAIN1 * GAIN2 * GAIN3 * 4096. / 3.3
-CAPGAIN_LOW = RLOW * GAIN1 * GAIN2 * GAIN3 * 4096. / 3.3
-
-class PinState(object):
-    """Data record to store the state of purpledrop pin setting, including 
-    active pins and capacitance scan groups
-    """
-    N_DRIVE_GROUPS = 2
-    N_SCAN_GROUPS = 5
-
-    class PinGroup(object):
-        def __init__(self, pin_mask: Sequence[int], setting: int):
-            self.pin_mask = pin_mask
-            self.setting = setting
-
-    class DriveGroup(PinGroup):
-        def __init__(self, pin_mask=None, duty_cycle=255):
-            if pin_mask is None:
-                pin_mask = pinlist2bool([])
-            super().__init__(pin_mask, duty_cycle)
-
-        @property
-        def duty_cycle(self):
-            return self.setting
-
-        @duty_cycle.setter
-        def duty_cycle(self, dc):
-            self.setting = dc
-
-        def to_dict(self):
-            return {
-                'pins': self.pin_mask,
-                'duty_cycle': self.duty_cycle,
-            }
-
-    class ScanGroup(PinGroup):
-        def __init__(self, pin_mask=None, setting=0):
-            if pin_mask is None:
-                pin_mask = pinlist2bool([])
-            super().__init__(pin_mask, setting)
-
-        def to_dict(self):
-            return {
-                'pins': self.pin_mask,
-                'setting': self.setting,
-            }
-
-    def __init__(self):
-        self.drive_groups = [self.DriveGroup() for _ in range(self.N_DRIVE_GROUPS)]
-        self.scan_groups = [self.ScanGroup() for _ in range(self.N_SCAN_GROUPS)]
-
-    def to_dict(self):
-        return {
-            'drive_groups': [x.to_dict() for x in self.drive_groups],
-            'scan_groups': [x.to_dict() for x in self.scan_groups],
-        }
-
-class PurpleDropController(object):
-    # Define the method names which will be made available via RPC server
-    RPC_METHODS = [
-        'get_board_definition',
-        'get_parameter_definitions',
-        'get_parameter',
-        'set_parameter',
-        'get_bulk_capacitance',
-        'get_scan_capacitance',
-        'get_group_capacitance',
-        'get_active_capacitance',
-        'set_capacitance_group',
-        'set_electrode_pins',
-        'get_electrode_pins',
-        'set_feedback_command',
-        'move_drop',
-        'get_temperatures',
-        'set_pwm_duty_cycle',
-        'get_hv_supply_voltage',
-        'calibrate_capacitance_offset',
-        'get_device_info',
-        'read_gpio',
-        'write_gpio',
-        'set_scan_gains',
-        'get_scan_gains',
-        'set_electrode_calibration',
-    ]
-
-    def __init__(self, purpledrop, board_definition: Board, electrode_calibration: Optional[ElectrodeOffsetCalibration]=None):
-        self.purpledrop = purpledrop
-        self.board_definition = board_definition
-
-        self.active_capacitance = 0.0
-        self.electrode_calibration = electrode_calibration
-        self.raw_scan_capacitance: List[float] = []
-        self.calibrated_scan_capacitance: List[float] = []
-        self.raw_group_capacitance: List[float] = []
-        self.calibrated_group_capacitance: List[float] = []
-        self.scan_gains = [1.0] * N_PINS
-        self.temperatures: Sequence[float] = []
-        self.duty_cycles: Dict[int, float] = {}
-        self.hv_supply_voltage = 0.0
-        self.parameter_list: List[dict] = []
-        self.lock = threading.Lock()
-        self.event_listeners: List[Callable] = []
-        self.active_capacitance_counter = 0
-        self.group_capacitance_counter = 0
-        self.duty_cycle_updated_counter = 0
-        self.hv_regulator_counter = 0
-        self.pin_state = PinState()
-
-        def msg_filter(msg):
-            desired_types = [
-                messages.ActiveCapacitanceMsg,
-                messages.BulkCapacitanceMsg,
-                messages.CommandAckMsg,
-                messages.DutyCycleUpdatedMsg,
-                messages.TemperatureMsg,
-                messages.HvRegulatorMsg,
-            ]
-
-            for t in desired_types:
-                if isinstance(msg, t):
-                    return True
-            return False
-        
-        if self.purpledrop.connected():
-            self.__on_connected()
-        self.purpledrop.register_connected_callback(self.__on_connected)
-        self.purpledrop.register_disconnected_callback(self.__on_disconnected)
-
-        self.listener = self.purpledrop.get_async_listener(self.__message_callback, msg_filter)
-
-    def __on_connected(self):
-        self.__set_scan_gains()
-        self.__get_parameter_descriptors()
-        software_version = self.get_software_version()
-        if not validate_version(software_version):
-            logger.error(f"Unsupported software version '{software_version}'. This driver may not" + \
-                "work correcly, and you should upgrade your purpledrop firmware to one of the following: " +  \
-                    f"{SUPPORTED_VERSIONS}")
-        self.__send_device_info_event(
-            True, 
-            self.purpledrop.connected_serial_number() or '',
-            software_version or ''
-        )
-        if self.electrode_calibration is not None:
-            logger.info("Loading electrode calibration")
-            self.set_electrode_calibration(self.electrode_calibration.voltage, self.electrode_calibration.offsets)
-
-    def __on_disconnected(self):
-        self.__send_device_info_event(False, '', '')
-
-    def __send_device_info_event(self, connected: bool, serial_number: str, software_version: str):
-        event = messages_pb2.PurpleDropEvent()
-        event.device_info.connected = connected
-        event.device_info.serial_number = serial_number
-        event.device_info.software_version = software_version
-        self.__fire_event(event)
-
-    def __get_parameter_descriptors(self):
-        """Request and receive the list of parameters from device 
-        """
-        listener = self.purpledrop.get_sync_listener(messages.ParameterDescriptorMsg)
-        self.purpledrop.send_message(messages.ParameterDescriptorMsg())
-        descriptors = []
-        while True:
-            msg = listener.wait(timeout=1.0)
-            if msg is None:
-                logger.error("Timed out waiting for parameter descriptors")
-                break
-            descriptors.append({
-                'id': msg.param_id,
-                'name': msg.name,
-                'description': msg.description,
-                'type': msg.type,
-            })
-            if msg.sequence_number == msg.sequence_total - 1:
-                break
-        self.parameter_list = descriptors
-
-    def __set_scan_gains(self, gains: Sequence[bool]=None):
-        """Setup gains used for capacitance scan
-
-        If no gains are provided, the gains will be set based on the "oversized"
-        electrodes defined in the active board definition. Any oversized
-        electrodes are set to low gain, and the rest to high gain.
-
-        Args:
-          gains: A list of booleans. True indicates low gain should be used for
-          the corresponding electrode
-        """
-        if gains is None:
-            gains = [False] * N_PINS
-            for pin in self.board_definition.oversized_electrodes:
-                gains[pin] = True # low gain
-        self.scan_gains = list(map(lambda x: CAPGAIN_LOW if x else CAPGAIN_HIGH, gains))
-
-        msg = messages.SetGainMsg()
-        msg.gains = list(map(lambda x: 1 if x else 0, gains))
-        listener = self.purpledrop.get_sync_listener(messages.CommandAckMsg)
-        self.purpledrop.send_message(msg)
-        ack = listener.wait(timeout=1.0)
-        if ack is None:
-            logger.error("Got no ACK for SetGains message")
-
-    def __calibrate_capacitance(self, raw, gain):
-        # Can't measure capacitance unless high voltage is on
-        if self.hv_supply_voltage < 60.0:
-            return 0.0
-        # Return as pF
-        return raw * 1e12 / gain / self.hv_supply_voltage
-        
-    def __message_callback(self, msg):
-        if isinstance(msg, messages.ActiveCapacitanceMsg):
-            # TODO: I-sense resistor values are adjustable, and the
-            # CAPGAIN_HIGH/CAPGAIN_LOW should be gotten from the device at some
-            # point, rather than duplicated here
-            capgain = CAPGAIN_LOW if (msg.settings & 1 == 1) else CAPGAIN_HIGH
-            self.active_capacitance = self.__calibrate_capacitance(msg.measurement - msg.baseline, capgain)
-            self.active_capacitance_counter += 1
-            # Throttle the events. 500Hz messages is a lot for the browser to process.
-            # This also means logs don't have a full resolution, and it would be better
-            # if clients could choose what they get
-            if (self.active_capacitance_counter % 10) == 0:
-                cap_event = messages_pb2.PurpleDropEvent()
-                cap_event.active_capacitance.baseline = msg.baseline
-                cap_event.active_capacitance.measurement = msg.measurement
-                cap_event.active_capacitance.calibrated = float(self.active_capacitance)
-                cap_event.active_capacitance.timestamp.CopyFrom(get_pb_timestamp())
-                self.__fire_event(cap_event)
-
-        elif isinstance(msg, messages.BulkCapacitanceMsg):
-            if(msg.group_scan != 0):
-                self.group_capacitance_counter += 1
-                if (self.group_capacitance_counter % 10) == 0:
-                    self.raw_group_capacitance = msg.measurements
-                    self.calibrated_group_capacitance = [0.0] * len(self.raw_group_capacitance)
-                    for i in range(msg.count):
-                        if self.pin_state.scan_groups[i].setting == 0:
-                            gain = CAPGAIN_HIGH
-                        else:
-                            gain = CAPGAIN_LOW
-                        self.calibrated_group_capacitance[i] = self.__calibrate_capacitance(msg.measurements[i], gain)
-                    group_event = messages_pb2.PurpleDropEvent()
-                    group_event.group_capacitance.timestamp.CopyFrom(get_pb_timestamp())
-                    group_event.group_capacitance.measurements[:] = self.calibrated_group_capacitance
-                    group_event.group_capacitance.raw_measurements[:] = self.raw_group_capacitance
-                    self.__fire_event(group_event)
-            else:
-                # Scan capacitance measurements are broken up into multiple messages
-                if len(self.raw_scan_capacitance) < msg.start_index + msg.count:
-                    self.raw_scan_capacitance.extend([0] * (msg.start_index + msg.count - len(self.raw_scan_capacitance)))
-                    self.calibrated_scan_capacitance.extend([0] * (msg.start_index + msg.count - len(self.calibrated_scan_capacitance)))
-                for i in range(msg.count):
-                    chan = msg.start_index + i
-                    gain = self.scan_gains[chan]
-                    self.raw_scan_capacitance[chan] = msg.measurements[i]
-                    self.calibrated_scan_capacitance[chan] = self.__calibrate_capacitance(msg.measurements[i], gain)
-                # Fire event on the last group
-                if msg.start_index + msg.count == 128:
-                    bulk_event = messages_pb2.PurpleDropEvent()
-                    def make_cap_measurement(raw, calibrated):
-                        m = messages_pb2.CapacitanceMeasurement()
-                        m.raw = float(raw)
-                        m.capacitance = float(calibrated)
-                        return m
-                    bulk_event.scan_capacitance.measurements.extend(
-                        [make_cap_measurement(raw, cal)
-                        for (raw, cal) in zip(self.raw_scan_capacitance, self.calibrated_scan_capacitance)]
-                    )
-                    bulk_event.scan_capacitance.timestamp.CopyFrom(get_pb_timestamp())
-                    self.__fire_event(bulk_event)
-
-        elif isinstance(msg, messages.DutyCycleUpdatedMsg):
-            self.duty_cycle_updated_counter += 1
-            if (self.duty_cycle_updated_counter%10) == 0:
-                # Update local state of duty cycle
-                self.pin_state.drive_groups[0].duty_cycle = msg.duty_cycle_A
-                self.pin_state.drive_groups[1].duty_cycle = msg.duty_cycle_B
-
-                # Publish event with new values
-                duty_cycle_event = messages_pb2.PurpleDropEvent()
-                duty_cycle_event.duty_cycle_updated.timestamp.CopyFrom(get_pb_timestamp())
-                duty_cycle_event.duty_cycle_updated.duty_cycles[:] = [msg.duty_cycle_A, msg.duty_cycle_B]
-                self.__fire_event(duty_cycle_event)
-
-        elif isinstance(msg, messages.HvRegulatorMsg):
-            self.hv_regulator_counter += 1
-            if (self.hv_regulator_counter % 10) == 0:
-                self.hv_supply_voltage = msg.voltage
-                event = messages_pb2.PurpleDropEvent()
-                event.hv_regulator.voltage = msg.voltage
-                event.hv_regulator.v_target_out = msg.v_target_out
-                event.hv_regulator.timestamp.CopyFrom(get_pb_timestamp())
-                self.__fire_event(event)
-
-        elif isinstance(msg, messages.TemperatureMsg):
-            self.temperatures = [float(x) / 100.0 for x in msg.measurements]
-            event = messages_pb2.PurpleDropEvent()
-            event.temperature_control.temperatures[:] = self.temperatures
-            duty_cycles = []
-            for i in range(len(self.temperatures)):
-                duty_cycles.append(self.duty_cycles.get(i, 0.0))
-            event.temperature_control.duty_cycles[:] = duty_cycles
-            event.temperature_control.timestamp.CopyFrom(get_pb_timestamp())
-            self.__fire_event(event)
-
-    def __fire_event(self, event):
-        with self.lock:
-            for listener in self.event_listeners:
-                listener(event)
-
-    def __get_parameter_definition(self, id):
-        for p in self.parameter_list:
-            if p['id'] == id:
-                return p
-        return None
-
-    def __fire_pinstate_event(self):
-        def create_electrode_group(x):
-            eg = messages_pb2.ElectrodeGroup()
-            eg.electrodes[:] = x.pin_mask
-            eg.setting = x.setting
-            return eg
-        event = messages_pb2.PurpleDropEvent()
-        for g in self.pin_state.drive_groups:
-            event.electrode_state.drive_groups.add(electrodes=g.pin_mask, setting=g.setting)
-        for g in self.pin_state.scan_groups:
-            event.electrode_state.scan_groups.add(electrodes=g.pin_mask, setting=g.setting)
-
-        self.__fire_event(event)
-
-    def get_software_version(self) -> Optional[str]:
-        listener = self.purpledrop.get_sync_listener(msg_filter=messages.DataBlobMsg)
-        versionRequest = messages.DataBlobMsg()
-        versionRequest.blob_id = messages.DataBlobMsg.SOFTWARE_VERSION_ID
-        self.purpledrop.send_message(versionRequest)
-        msg = listener.wait(0.5)
-        if msg is None:
-            software_version = None
-            logger.warning("Timed out requesting software version")
-        else:
-            software_version = msg.payload.decode('utf-8')
-        return software_version
-
-    def register_event_listener(self, func):
-        """Register a callback for state update events
-        """
-        with self.lock:
-            self.event_listeners.append(func)
-
-    def get_parameter_definitions(self):
-        """Get a list of all of the parameters supported by the PurpleDrop
-
-        Arguments:
-          - None
-        """
-        logger.debug("Recieved get_parameter_definitions")
-        return {
-            "parameters": self.parameter_list,
-        }
-
-    def get_parameter(self, paramIdx):
-        """Request the current value of a parameter from the device
-
-        Arguments:
-          - paramIdx: The ID of the parameter to request (from the list of
-            parameters provided by 'get_parameter_definition')
-        """
-        req_msg = messages.SetParameterMsg()
-        req_msg.set_param_idx(paramIdx)
-        req_msg.set_param_value_int(0)
-        req_msg.set_write_flag(0)
-        def msg_filter(msg):
-            return isinstance(msg, messages.SetParameterMsg) and msg.param_idx() == paramIdx
-        listener = self.purpledrop.get_sync_listener(msg_filter=msg_filter)
-        self.purpledrop.send_message(req_msg)
-        resp = listener.wait(timeout=0.5)
-        if resp is None:
-            raise TimeoutError("No response from purpledrop")
-        else:
-            paramDesc = self.__get_parameter_definition(paramIdx)
-            value = None
-            if paramDesc is not None and paramDesc['type'] == 'float':
-                value = resp.param_value_float()
-            else:
-                value = resp.param_value_int()
-            logger.debug(f"get_parameter({paramIdx}) returning {value}")
-            return value
-
-    def set_parameter(self, paramIdx, value):
-        """Set a config parameter
-
-        A special paramIdx value of 0xFFFFFFFF is used to trigger the saving
-        of all parameters to flash.
-
-        Arguments:
-            - paramIdx: The index of the parameter to set (from
-             'get_parameter_definitions')
-            - value: A float or int (based on the definition) with the new
-              value to assign
-        """
-        logging.debug(f"Received set_parameter({paramIdx}, {value})")
-        req_msg = messages.SetParameterMsg()
-        req_msg.set_param_idx(paramIdx)
-        paramDesc = self.__get_parameter_definition(paramIdx)
-        if paramDesc is not None and paramDesc['type'] == 'float':
-            req_msg.set_param_value_float(value)
-        else:
-            req_msg.set_param_value_int(value)
-        req_msg.set_write_flag(1)
-        def msg_filter(msg):
-            return isinstance(msg, messages.SetParameterMsg) and msg.param_idx() == paramIdx
-        listener = self.purpledrop.get_sync_listener(msg_filter=msg_filter)
-        self.purpledrop.send_message(req_msg)
-        resp = listener.wait(timeout=0.5)
-        if resp is None:
-            raise TimeoutError(f"No response from purpledrop to set parameter ({paramIdx})")
-
-    def get_board_definition(self):
-        """Get electrode board configuratin object
-
-        Arguments: None
-        """
-        logger.debug(f"Received get_board_definition")
-        return self.board_definition.as_dict()
-
-    def get_bulk_capacitance(self) -> List[float]:
-        """Get the most recent capacitance scan results
-
-        DEPRECATED. Use get_scan_capacitance.
-
-        Arguments: None
-        """
-        logging.debug("Received get_bulk_capacitance")
-        return self.calibrated_scan_capacitance
-
-    def get_scan_capacitance(self) -> Dict[str, Any]:
-        """Get the most recent capacitance scan results
-
-        Arguments: None
-        """
-        return {
-            "raw": self.raw_scan_capacitance,
-            "calibrated": self.calibrated_scan_capacitance
-        }
-
-    def get_group_capacitance(self) -> Dict[str, List[float]]:
-        """Get the latest group scan capacitances
-
-        Arguments: None
-        """
-        return {
-            "raw": self.raw_group_capacitance,
-            "calibrated": self.calibrated_group_capacitance,
-        }
-
-    def get_active_capacitance(self) -> float:
-        """Get the most recent active electrode capacitance
-
-        Arguments: None
-        """
-        logging.debug("Received get_active_capacitance")
-        return self.active_capacitance
-
-    def get_electrode_pins(self):
-        """Get the current state of all electrodes
-
-        Arguments: None
-
-        Returns: List of booleans
-        """
-        logging.debug("Received get_electrode_pins")
-        return self.pin_state.to_dict()
-
-    def set_capacitance_group(self, pins: Sequence[int], group_id: int, setting: int):
-        """Set a capacitance scan group.
-
-        Purpledrop support 5 scan groups. Each group defines a set of electrodes
-        which are measured together after each AC drive cycle.
-
-        Arguments:
-          - pins: A list of pins included in the group (may be empty to clear the group)
-          - group_id: The group number to set (0-4)
-        """
-        if group_id >= 5:
-            raise ValueError("group_id must be < 5")
-
-        # Send message to device to update
-        msg = ElectrodeEnableMsg()
-        msg.group_id = group_id + 100
-        msg.setting = setting
-        msg.values = pinlist2mask(pins)
-        self.purpledrop.send_message(msg)
-
-        # Update local state
-        self.pin_state.scan_groups[group_id] = PinState.ScanGroup(pinlist2bool(pins), setting)
-
-        # Send event with new state
-        self.__fire_pinstate_event()
-
-    def set_electrode_pins(self, pins: Sequence[int], group_id: int=0, duty_cycle: int=255):
-        """Set the currently enabled pins
-
-        Specified electrodes will be activated, all other will be deactivated.
-        Providing an empty array will deactivate all electrodes.
-
-        Arguments:
-            - pins: A list of pin numbers to activate
-            - group_id: Which electrode enable group to be set (default: 0)
-                0: Drive group A
-                1: Drive group B
-            - duty_cycle: Duty cycle for the group (0-255)
-        """
-        logging.debug(f"Received set_electrode_pins({pins})")
-
-        if group_id < 0 or group_id > 1:
-            raise ValueError(f"group_id={group_id} is invalid. It must be 0 or 1.")
-
-        # Send message to device to update
-        msg = ElectrodeEnableMsg()
-        msg.group_id = group_id
-        msg.setting = duty_cycle
-        msg.values = pinlist2mask(pins)
-        self.purpledrop.send_message(msg)
-
-        # Update local state
-        self.pin_state.drive_groups[group_id] = PinState.DriveGroup(pinlist2bool(pins), duty_cycle)
-
-        # Send event with new state
-        self.__fire_pinstate_event()
-
-    def set_feedback_command(self, target, mode, input_groups_p_mask, input_groups_n_mask, baseline):
-        """Update feedback control settings
-
-        When enabled, the purpledrop controller will adjust the duty cycle of
-        electrode drive groups based on capacitance measurements.
-
-        Arguments:
-            - target: The controller target in counts
-            - mode:
-                - 0: Disabled
-                - 1: Normal
-                - 2: Differential
-            - input_groups_p_mask: Bit mask indicating which capacitance groups to 
-              sum for positive input (e.g. for groups 0 and 2: 5)
-            - input_groups_n_mask: Bit mask for negative input groups (used in differential mode)
-            - baseline: The duty cycle to apply to both drive groups when no error signal is 
-              present (0-255)
-        """
-        msg = messages.FeedbackCommandMsg()
-        msg.target = target
-        msg.mode = mode
-        msg.input_groups_p_mask = input_groups_p_mask
-        msg.input_groups_n_mask = input_groups_n_mask
-        msg.baseline = baseline
-        self.purpledrop.send_message(msg)
-
-    def move_drop(self,
-                  start: Sequence[int],
-                  size: Sequence[int],
-                  direction: str) -> MoveDropResult:
-        """Execute a drop move sequence
-
-        Arguments:
-            - start: A list -- [x, y] -- specifying the top-left corner of the current drop location
-            - size: A list -- [width, height] -- specifying the size of the drop to be moved
-            - direction: One of, "Up", "Down", "Left", "Right"
-        """
-        logging.debug(f"Received move_drop({start}, {size}, {direction})")
-        return move_drop(self, start, size, direction)
-
-    def get_temperatures(self) -> Sequence[float]:
-        """Returns an array of all temperature sensor measurements in degrees C
-
-        Arguments: None
-        """
-        logging.debug("Received get_temperatures")
-        return self.temperatures
-
-    def set_pwm_duty_cycle(self, chan: int, duty_cycle: float):
-        """Set the PWM output duty cycle for a single channel
-
-        Arguments:
-            - chan: An integer specifying the channel to set
-            - duty_cycle: A float specifying the duty cycle in range [0, 1.0]
-        """
-        logging.debug(f"Received set_pwm_duty_cycle({chan}, {duty_cycle})")
-        self.duty_cycles[chan] = duty_cycle
-        msg = SetPwmMsg()
-        msg.chan = chan
-        msg.duty_cycle = duty_cycle
-        self.purpledrop.send_message(msg)
-
-    def get_hv_supply_voltage(self):
-        """Return the latest high voltage rail measurement
-
-        Arguments: None
-
-        Returns: A float, in volts
-        """
-        logging.debug("Received get_hv_supply_voltage")
-        return self.hv_supply_voltage
-
-    def calibrate_capacitance_offset(self):
-        """Request a calibration of the capacitance measurement zero offset
-
-        Arguments: None
-
-        Returns: None
-        """
-        msg = messages.CalibrateCommandMsg()
-        msg.command = messages.CalibrateCommandMsg.CAP_OFFSET_CMD
-        self.purpledrop.send_message(msg)
-
-    def get_device_info(self):
-        """Gets information about the connected purpledrop device
-
-        Arguments: None
-
-        Returns: Object with the following fields: 
-          - connected: boolean indicating if a device is currently connected
-          - serial_number: The serial number of the connected device
-          - software_version: The software version string of the connected device
-        """
-        serial_number = self.purpledrop.connected_serial_number()
-        if serial_number is None:
-            return {
-                'connected': False,
-                'serial_number': '',
-                'software_version': ''
-            }
-        else:
-            software_version = self.get_software_version()
-            return {
-                'connected': True,
-                'serial_number': serial_number,
-                'software_version': software_version
-            }
-
-    def read_gpio(self, gpio_num):
-        """Reads the current input value of a GPIO pin
-
-        Arguments:
-          - gpio_num:  The ID of the GPIO to read
-
-        Returns: A bool
-        """
-        msg = messages.GpioControlMsg()
-
-        msg.pin = gpio_num
-        msg.read = True
-
-        listener = self.purpledrop.get_sync_listener(msg_filter=messages.GpioControlMsg)
-        self.purpledrop.send_message(msg)
-        rxmsg  = listener.wait(0.5)
-        if rxmsg is None:
-            raise TimeoutError("No response from purpledrop to GPIO read request")
-        else:
-            return rxmsg.value
-
-    def write_gpio(self, gpio_num, value, output_enable):
-        """Set the output state of a GPIO pin
-
-        Arguments:
-          - gpio_num: The ID of the GPIO to set
-          - value: The output value (boolean)
-          - output_enable: Set the GPIO as an output (true) or input (false)
-
-        Returns:
-          - The value read on the GPIO (bool)
-        """
-        msg = messages.GpioControlMsg()
-
-        msg.pin = gpio_num
-        msg.read = False
-        msg.value = value
-        msg.output_enable = output_enable
-
-        listener = self.purpledrop.get_sync_listener(msg_filter=messages.GpioControlMsg)
-        self.purpledrop.send_message(msg)
-        rxmsg  = listener.wait(0.5)
-        if rxmsg is None:
-            raise TimeoutError("No response from purpledrop to GPIO read request")
-        else:
-            return rxmsg.value
-
-    def set_electrode_calibration(self, voltage: float, offsets: Sequence[int]):
-        """Set the capacitance offset for each electrode
-
-        Provides a table of values to be subtracted for each electrode to
-        compensate for parasitic capacitance of the electrode. Values are
-        measured at high gain, with no liquid on the device, at a certain
-        voltage.
-
-        These values will be adjusted for changes in voltage from the measured
-        voltage, and for low gain when applied by the purpledrop.
-
-        Arguments:
-          - voltage: The voltage setting at which the offsets were measured
-          - offsets: A list of 128 16-bit values to be subtracted
-
-        Returns: None
-        """
-        offsets = list(map(int, offsets))
-        table = struct.pack("<f128H", voltage, *offsets)
-
-        tx_pos = 0
-        while tx_pos < len(table):
-            tx_size = min(64, len(table) - tx_pos)
-            msg = messages.DataBlobMsg()
-            msg.blob_id = msg.OFFSET_CALIBRATION_ID
-            msg.chunk_index = tx_pos
-            msg.payload_size = tx_size
-            msg.payload = table[tx_pos:tx_pos+tx_size]
-            tx_pos += tx_size
-            listener = self.purpledrop.get_sync_listener(messages.CommandAckMsg)
-            self.purpledrop.send_message(msg)
-            ack = listener.wait(timeout=0.5)
-            if ack is None:
-                raise TimeoutError("No ACK while setting electrode calibration")
-
-    def set_scan_gains(self, gains: Optional[Sequence[bool]]=None):
-        """Set the gains used for capacitance scan measurement
-
-        If no gains argument is provided, scan gains will be set based on
-        oversized electrodes defined in the board definition file.
-
-        Arguments:
-          - gains: A list of 128 booleans, true indicating that an electrode
-            should be scanned with low gain
-        """
-        if gains is not None:
-            if len(gains) != 128:
-                raise ValueError("Scan gains must have 128 values")
-            # Make sure they are all convertible to bool
-            gains = [bool(x) for x in gains]
-        self.__set_scan_gains(gains)
-
-    def get_scan_gains(self) -> List[bool]:
-        """Return the current scan gain settings
-        """
-        return [x == CAPGAIN_LOW for x in self.scan_gains]

--- a/purpledrop/script/pd_cli.py
+++ b/purpledrop/script/pd_cli.py
@@ -1,7 +1,7 @@
 import click
 import sys
 
-from purpledrop.purpledrop import PurpleDropDevice, list_purpledrop_devices
+from purpledrop.purpledrop import SerialPurpleDropDevice, list_purpledrop_devices
 import purpledrop.messages as messages
 
 def get_device():
@@ -27,13 +27,13 @@ def info():
     device = get_device()
     port = device.device
     print(f"Connecting to {port}")
-    pd = PurpleDropDevice(port)
-    listener = pd.get_sync_listener(msg_filter=messages.DataBlobMsg)
-    versionRequest = messages.DataBlobMsg()
-    versionRequest.blob_id = messages.DataBlobMsg.SOFTWARE_VERSION_ID
-    pd.send_message(versionRequest)
-    msg = listener.wait(1.0)
     print(f"Serial number: {device.serial_number}")
+    pd = SerialPurpleDropDevice(port)
+    with pd.get_sync_listener(msg_filter=messages.DataBlobMsg) as listener:
+        versionRequest = messages.DataBlobMsg()
+        versionRequest.blob_id = messages.DataBlobMsg.SOFTWARE_VERSION_ID
+        pd.send_message(versionRequest)
+        msg = listener.next(1.0)
     if msg is None:
         print("Timeout waiting for version response")
     else:

--- a/purpledrop/script/pd_server.py
+++ b/purpledrop/script/pd_server.py
@@ -84,6 +84,7 @@ def main(verbose, board_file, replay_file, sim, electrode_calibration_file=None,
         drop_pins = [int(x) for x in sim.split(',')]
         pd_dev = SimulatedPurpleDropDevice(board, drop_pins)
         pd_control = PurpleDropController(pd_dev, board, ecal)
+        pd_dev.open()
     else:
         print("Launching HW server...")
         pd_dev = PersistentPurpleDropDevice()

--- a/purpledrop/server.py
+++ b/purpledrop/server.py
@@ -19,7 +19,7 @@ import logging
 import pkg_resources
 import tarfile
 
-from .purpledrop import PurpleDropController
+from .controller import PurpleDropController
 
 logger = logging.getLogger('purpledrop')
 

--- a/purpledrop/simulated_purpledrop.py
+++ b/purpledrop/simulated_purpledrop.py
@@ -1,0 +1,274 @@
+import threading
+import time
+import queue
+
+import purpledrop.messages as messages
+from .purpledrop import PurpleDropDevice
+
+def pinmask2list(mask):
+    assert len(mask) == 16
+    pins = []
+    for p in range(128):
+        bit = p % 8
+        offset = int(p / 8)
+        if (mask[offset] & (1<<bit)) != 0:
+            pins.append(p)
+    return pins
+
+class ElectrodeNode(object):
+    def __init__(self, state=False):
+        self.state = state
+        self.volume = 0.0
+        self.just_moved = False
+        self.recurse_flag = False
+        self.__connections = []
+
+    def add_connection(self, neighbor):
+        if neighbor in self.__connections:
+            return
+        self.__connections.append(neighbor)
+        neighbor.add_connection(self)
+
+    def connections(self):
+        return self.__connections
+
+def is_pullable(e: ElectrodeNode, dst: ElectrodeNode):
+    if e.volume == 0 or e.just_moved:
+        return False
+    if not e.state:
+        return True
+    for c in e.connections():
+        # Don't recurse back through a node we already traversed, lest we get
+        # stuck in a loop
+        if c == dst or c.recurse_flag:
+            continue
+        try:
+            e.recurse_flag = True
+            if is_pullable(c, e):
+                return True
+        finally:
+            e.recurse_flag = False
+
+    return False
+
+def pull_drop(cur: ElectrodeNode, dst: ElectrodeNode):
+    """Pull drop on cur onto dst
+
+    Recursively
+    """
+    assert dst.volume == 0.0
+    assert cur.volume == 1.0
+    dst.volume = 1.0
+    cur.volume = 0.0
+    dst.just_moved = True
+    for c in cur.connections():
+        if is_pullable(c, cur):
+            pull_drop(c, cur)
+            break
+
+class SimulatedPurpleDropDevice(PurpleDropDevice):
+    """Acts like a purpledrop device, sending and receiving messages
+
+    Includes a simple drop movement model, which supports drop movement within
+    electrode grid only.
+    """
+    # Capacitance (counts) for each covered electrode
+    UNIT_CAPACITANCE = 1000
+    GAIN_RATIO = 7
+
+    N_CGROUPS = 5
+
+    def __init__(self, board, drop_locations):
+        super().__init__()
+        self.electrodes = [ElectrodeNode() for _ in range(128)]
+        self.msg_queue = queue.Queue()
+        self.drive_a_values = [0] * 16
+        self.drive_b_values = [0] * 16
+        self.scan_groups = [{'pins': [], 'setting': 0} for _ in range(self.N_CGROUPS)]
+        self.__connected = False
+
+        # Populate initial drops
+        for pin in drop_locations:
+            self.electrodes[pin].volume = 1.0
+
+        self.__load_board(board)
+
+        self.__thread = threading.Thread(target=self.__thread_entry, name="Simulated PurpleDrop", daemon=True)
+        self.__thread.start()
+
+    def open(self):
+        self.__connected = True
+        self.on_connected()
+
+    def close(self):
+        self.__connected = False
+        self.on_disconnected()
+
+    def connected(self):
+        return self.__connected
+
+    def send_message(self, msg):
+        """Override the PurpleDropDevice send method to receive messages"""
+        # Put message into queue for background thread to handle
+        self.msg_queue.put(msg)
+
+    def __thread_entry(self):
+        cycle_counter = 0
+        while True:
+            # Process incoming messages
+            while True:
+                try:
+                    msg = self.msg_queue.get(block=False)
+
+                    if isinstance(msg, messages.ElectrodeEnableMsg):
+                        self.__handle_set_electrode(msg)
+                    if isinstance(msg, messages.DataBlobMsg):
+                        self.__handle_data_blob(msg)
+
+                except queue.Empty:
+                    break
+
+            # Send messages
+            if (cycle_counter % 5) == 0:
+                self.__send_hv_supply_voltage()
+            self.__send_active_capacitance()
+            self.__send_group_capacitance()
+            if (cycle_counter % 5) == 0:
+                self.__send_capacitance_scan()
+
+            # Update state
+            self.__update_drop_positions()
+
+            cycle_counter += 1
+            time.sleep(0.05)
+
+    def __handle_data_blob(self, msg: messages.DataBlobMsg):
+        if msg.blob_id == messages.DataBlobMsg.SOFTWARE_VERSION_ID:
+            resp = messages.DataBlobMsg()
+
+            resp.payload = b"Simulated"
+            resp.payload_size = len(resp.payload)
+            resp.blob_id = messages.DataBlobMsg.SOFTWARE_VERSION_ID;
+            resp.chunk_index = 0
+            self.on_message_received(resp)
+
+    def __handle_set_electrode(self, msg: messages.ElectrodeEnableMsg):
+        if msg.group_id >= 100:
+            scan_group_id = msg.group_id - 100
+            self.scan_groups[scan_group_id] = {
+                'pins': pinmask2list(msg.values),
+                'setting': msg.setting
+            }
+        else:
+            if msg.group_id == 1:
+                self.drive_b_values = msg.values
+            else:
+                self.drive_a_values = msg.values
+
+            def is_enabled(pin, values):
+                assert(pin < 128)
+                bit = pin % 8
+                offset = int(pin / 8)
+                return (values[offset] & (1<<bit)) != 0
+
+            for pin in range(128):
+                if is_enabled(pin, self.drive_b_values) or is_enabled(pin, self.drive_a_values):
+                    self.electrodes[pin].state = True
+                else:
+                    self.electrodes[pin].state = False
+
+        ack = messages.CommandAckMsg()
+        ack.acked_id = messages.ElectrodeEnableMsg.ID
+        self.on_message_received(ack)
+
+    def __send_hv_supply_voltage(self):
+        msg = messages.HvRegulatorMsg()
+        msg.voltage = 100.0
+        msg.v_target_out = 0
+        self.on_message_received(msg)
+
+    def __send_active_capacitance(self):
+        capacitance = 0.0
+        for pin in range(128):
+            e = self.electrodes[pin]
+            if e.state and e.volume > 0.0:
+                capacitance += self.UNIT_CAPACITANCE
+        capacitance = min(capacitance, 4095)
+        active_cap_msg = messages.ActiveCapacitanceMsg()
+        active_cap_msg.settings = 0
+        active_cap_msg.baseline = 0
+        active_cap_msg.measurement = int(capacitance)
+
+    def __send_group_capacitance(self):
+        capacitance = [0.0] * self.N_CGROUPS
+        for i in range(self.N_CGROUPS):
+            cgroup = self.scan_groups[i]
+            for pin in cgroup['pins']:
+                e = self.electrodes[pin]
+                if cgroup['setting'] != 0:
+                    capacitance[i] += e.volume * self.UNIT_CAPACITANCE / self.GAIN_RATIO
+                else:
+                    capacitance[i] += e.volume * self.UNIT_CAPACITANCE
+
+        bulk_msg = messages.BulkCapacitanceMsg()
+        bulk_msg.start_index = 0
+        bulk_msg.group_scan = 1
+        bulk_msg.count = self.N_CGROUPS
+        bulk_msg.measurements = list([int(c) for c in capacitance])
+
+        self.on_message_received(bulk_msg)
+
+    def __send_capacitance_scan(self):
+        values = [0] * 128
+        for pin in range(128):
+            if self.electrodes[pin].volume > 0.0:
+                values[pin] = self.UNIT_CAPACITANCE
+        # The actual device splits the capacitances over many messages
+        # Here, we just make one long message.
+        msg = messages.BulkCapacitanceMsg()
+        msg.start_index = 0
+        msg.group_scan = 0
+        msg.count = 128
+        msg.measurements = values
+        self.on_message_received(msg)
+
+    def __update_drop_positions(self):
+        for e in self.electrodes:
+            e.just_moved = False
+        for i, e in enumerate(self.electrodes):
+            if e.state and e.volume == 0.0:
+                for c in e.connections():
+                    if is_pullable(c, e):
+                        pull_drop(c, e)
+                        break
+
+    def __load_board(self, board):
+        """Create map of electrode connections from board layout
+
+        Currently this only supports grid electrodes, because it's easier.
+        This means other electrodes, such as reservoirs, will be left unconnected
+        and unable to move drops on or off. We could infer connections from
+        electrodes which are close, although this also raises issues of volume
+        because drops can then move between electrodes of different sizes.
+        """
+        for g in board.layout.grids:
+            pins = g['pins']
+            for y in range(len(pins)):
+                row = pins[y]
+                for x in range(len(row)):
+                    pin = row[x]
+                    if pin is None:
+                        continue
+                    if x < len(row) - 1:
+                        right_pin = row[x+1]
+                        if right_pin is None:
+                            continue
+                        self.electrodes[pin].add_connection(self.electrodes[right_pin])
+                    if y < len(pins) - 1:
+                        next_row = pins[y+1]
+                        if x < len(next_row):
+                            below_pin = next_row[x]
+                            if below_pin is None:
+                                continue
+                            self.electrodes[pin].add_connection(self.electrodes[below_pin])
+

--- a/setParam.py
+++ b/setParam.py
@@ -18,27 +18,27 @@ def main(id, value, float):
         msg.set_param_value_float(float(value))
     else:
         msg.set_param_value_int(int(value))
-    
+
     msg.set_write_flag(True)
 
     devices = list_purpledrop_devices()
     if(len(devices) == 0):
         print("No PurpleDrop USB device found")
         sys.exit(1)
-    elif len(devices) > 1: 
+    elif len(devices) > 1:
         print("Multiple PurpleDrop devices found. Please ammend software to allow selection by serial number")
         for d in devices:
             print(f"{d.device}: Serial {d.serial_number}")
         sys.exit(1)
     dev = PurpleDropDevice(devices[0].device)
-    listener = dev.get_sync_listener(msg_filter=SetParameterMsg)
-    dev.send_message(msg)
-    ack = listener.wait(timeout=1.0)
+    with dev.get_sync_listener(msg_filter=SetParameterMsg) as listener:
+        dev.send_message(msg)
+        ack = listener.next(timeout=1.0)
     if ack is None:
         print("No ACK message received")
     else:
         print("Got ACK: " + str(ack))
 
-    
+
 if __name__ == '__main__':
     main()

--- a/setPwm.py
+++ b/setPwm.py
@@ -14,28 +14,28 @@ def main(chan, duty_cycle):
     msg = SetPwmMsg()
     msg.chan = chan
     msg.duty_cycle = duty_cycle
-    
+
     devices = list_purpledrop_devices()
     if(len(devices) == 0):
         print("No PurpleDrop USB device found")
         sys.exit(1)
-    elif len(devices) > 1: 
+    elif len(devices) > 1:
         print("Multiple PurpleDrop devices found. Please ammend software to allow selection by serial number")
         for d in devices:
             print(f"{d.device}: Serial {d.serial_number}")
         sys.exit(1)
     print(f"Connecting to purple drop on {devices[0].device}")
     dev = PurpleDropDevice(devices[0].device)
-    listener = dev.get_sync_listener(msg_filter=CommandAckMsg)
-    print("Sending Message\n")
-    dev.send_message(msg)
-    print("Waiting for ack\n")
-    ack = listener.wait(timeout=1.0)
+    with dev.get_sync_listener(msg_filter=CommandAckMsg) as listener:
+        print("Sending Message\n")
+        dev.send_message(msg)
+        print("Waiting for ack\n")
+        ack = listener.next(timeout=1.0)
     if ack is None:
         print("No ACK message received")
     else:
         print("Got ACK: " + str(ack))
 
-    
+
 if __name__ == '__main__':
     main()

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ or via  a browser based UI""",
         'protobuf',
         'pyserial',
         'requests',
+        'schema',
     ],
     extras_require={
         'testing': [


### PR DESCRIPTION
- Add support for `move_drops` RPC, which moves up to five drops at once using
  group capacitance as feedback and adds support for control of more move options,
  including the gain to use, the timeout, and how much trailing data to collect
  ("post_capture_time").
- Changes move_drop to report calibrated capacitance in its return data
- Change background threads to greenlets
- Add simulation mode to pdserver with --sim argument